### PR TITLE
feat: 天候・季節イベント演出と作品間状態同期を整備

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 /tmp/*.js
 /tmp/*.mjs
 /tmp/*.gif
+/tmp/*.log
 /tmp/**/*.png
 /tmp/**/*.jpg
 /tmp/**/*.jpeg

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,14 @@
 /tmp/*.js
 /tmp/*.mjs
 /tmp/*.gif
+/tmp/**/*.png
+/tmp/**/*.jpg
+/tmp/**/*.jpeg
+/tmp/**/*.webp
+/tmp/**/*.mp4
+/tmp/**/*.webm
+/tmp/**/*.mov
+/tmp/**/*.avi
 
 # debug
 npm-debug.log*

--- a/e2e/otenkigurashi-weather.spec.ts
+++ b/e2e/otenkigurashi-weather.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const route = (weather: string, season = 'none', seasonEvent = 'none') =>
+    `/otenkigurashi?lang=ja&weather=${weather}&season=${season}&seasonEvent=${seasonEvent}`;
+
+const revealTenchan = async (page: Page) => {
+    await page.mouse.click(100, 100);
+    await expect(page.locator('[data-testid="tenchan-companion"]')).toHaveCount(1, { timeout: 5000 });
+};
+
+test.describe('Otenkigurashi weather presentation', () => {
+    test('shows only the matching Ten-chan weather accessory', async ({ page }) => {
+        const cases = [
+            { weather: 'Rain', accessory: 'rain' },
+            { weather: 'Thunder', accessory: 'thunder' },
+            { weather: 'Night', accessory: 'night' },
+            { weather: 'Snow', accessory: 'snow' },
+        ];
+
+        for (const current of cases) {
+            await page.goto(route(current.weather), { waitUntil: 'domcontentloaded' });
+            await revealTenchan(page);
+            await expect(page.locator(`[data-weather-accessory="${current.accessory}"]`)).toHaveCount(1);
+            await expect(page.locator('[data-weather-accessory]')).toHaveCount(1);
+        }
+    });
+
+    test('does not add a weather accessory for clear or cloudy weather', async ({ page }) => {
+        for (const weather of ['Clear', 'Clouds']) {
+            await page.goto(route(weather), { waitUntil: 'domcontentloaded' });
+            await revealTenchan(page);
+            await expect(page.locator('[data-weather-accessory]')).toHaveCount(0);
+        }
+    });
+
+    test('limits the winter scenery overlay to snow weather', async ({ page }) => {
+        await page.goto(route('Rain', 'winter'), { waitUntil: 'domcontentloaded' });
+        await expect(page.locator('.otenki-season-winter')).toHaveCount(0);
+
+        await page.goto(route('Snow', 'winter'), { waitUntil: 'domcontentloaded' });
+        await expect(page.locator('.otenki-season-winter')).toHaveCount(1);
+    });
+
+    test('uses the tsuyu atmosphere for each supported weather combination', async ({ page }) => {
+        for (const weather of ['Clear', 'Clouds', 'Rain']) {
+            await page.goto(route(weather, 'summer', 'tsuyu'), { waitUntil: 'domcontentloaded' });
+            await expect(page.locator('[data-testid="tsuyu-atmosphere"]')).toHaveCount(1);
+        }
+    });
+});
+
+test.describe('Denshouo weather presentation', () => {
+    test('renders marine snow only for Snow', async ({ page }) => {
+        await page.goto('/denshouo?lang=ja&weather=Snow&season=winter&seasonEvent=none', { waitUntil: 'domcontentloaded' });
+        await expect(page.locator('[data-testid="marine-snow"]')).toHaveCount(1);
+
+        await page.goto('/denshouo?lang=ja&weather=Rain&season=summer&seasonEvent=none', { waitUntil: 'domcontentloaded' });
+        await expect(page.locator('[data-testid="marine-snow"]')).toHaveCount(0);
+    });
+});

--- a/src/app/denshouo/DenshouoClient.tsx
+++ b/src/app/denshouo/DenshouoClient.tsx
@@ -718,19 +718,25 @@ export default function DenshouoClient() {
     const router = useRouter();
     const searchParams = useSearchParams();
     const lang = searchParams.get('lang') === 'en' ? 'en' : 'ja';
-    const { setActiveWork, weather } = useStore();
+    const { setActiveWork, setWeather, weather } = useStore();
     const weatherParam = searchParams.get('weather');
     const displayedWeather = VALID_WEATHERS.includes(weatherParam as WeatherType)
         ? weatherParam as WeatherType
         : weather;
 
     useEffect(() => {
-        if (weather !== 'Rain' || weatherParam) return;
+        if (weatherParam && VALID_WEATHERS.includes(weatherParam as WeatherType)) {
+            const nextWeather = weatherParam as WeatherType;
+            if (weather !== nextWeather) setWeather(nextWeather);
+            return;
+        }
+
+        if (weather !== 'Rain') return;
 
         const params = new URLSearchParams(searchParams.toString());
         params.set('weather', 'Rain');
         router.replace(`/denshouo?${params.toString()}`, { scroll: false });
-    }, [router, searchParams, weather, weatherParam]);
+    }, [router, searchParams, setWeather, weather, weatherParam]);
 
     const [showBackdrop, setShowBackdrop] = useState(true);
     const [ripples, setRipples] = useState<Array<{ id: number; x: number; y: number; size: number; isHover: boolean }>>([]);

--- a/src/app/denshouo/DenshouoClient.tsx
+++ b/src/app/denshouo/DenshouoClient.tsx
@@ -2,14 +2,13 @@
 
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useStore, type WeatherType } from '@/store';
-import { motion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { useMemo, useRef, useEffect, useState, useCallback } from 'react';
 import * as THREE from 'three';
 import { waveVertexShader, waveFragmentShader } from '@/shaders/wave';
 import Image from 'next/image';
-
-const VALID_WEATHERS: WeatherType[] = ['Clear', 'Rain', 'Clouds', 'Snow', 'Night', 'Morning', 'Thunder'];
+import { buildWorldStateQuery, parseWorldStateParams } from '@/lib/worldState';
 
 const bubbleSpecs = [
     { left: '8%', top: '18%', size: 16, delay: 0.0, duration: 8.0 },
@@ -32,6 +31,16 @@ const rainLightSpecs = [
     { left: '43%', width: 9, rotate: 5, delay: 1.8, duration: 11.0 },
     { left: '70%', width: 7, rotate: -4, delay: 0.9, duration: 10.2 },
 ];
+
+const marineSnowSpecs = Array.from({ length: 34 }, (_, index) => ({
+    left: 5 + ((index * 37) % 90),
+    size: 2 + ((index * 17) % 5),
+    drift: -24 + ((index * 29) % 49),
+    duration: 10 + ((index * 13) % 11),
+    delay: -((index * 7) % 16),
+    opacity: 0.20 + ((index * 11) % 25) / 100,
+    blur: index % 4 === 0 ? 2 : 0,
+}));
 
 const overviewFishSpecs = [
     { width: 84, duration: 18, src: '/clownfish.png', alt: 'clownfish' },
@@ -600,6 +609,36 @@ function OceanBubbles() {
     );
 }
 
+function MarineSnow() {
+    const reducedMotion = useReducedMotion();
+
+    return (
+        <div data-testid="marine-snow" className="fixed inset-0 pointer-events-none z-2 overflow-hidden" aria-hidden="true">
+            {marineSnowSpecs.map((particle, index) => (
+                <motion.span
+                    key={`marine-snow-${index}`}
+                    className="absolute rounded-full bg-cyan-50/75"
+                    style={{
+                        left: `${particle.left}%`,
+                        top: `${(index * 19) % 112 - 12}%`,
+                        width: particle.size,
+                        height: particle.size,
+                        opacity: particle.opacity,
+                        filter: particle.blur ? `blur(${particle.blur}px)` : undefined,
+                        boxShadow: '0 0 8px rgba(191,235,255,0.28)',
+                    }}
+                    animate={reducedMotion
+                        ? { x: 0, y: 0, opacity: particle.opacity }
+                        : { x: [0, particle.drift, particle.drift * -0.55, 0], y: ['-8vh', '38vh', '78vh', '116vh'], opacity: [0, particle.opacity, particle.opacity * 0.72, 0] }}
+                    transition={reducedMotion
+                        ? { duration: 0 }
+                        : { duration: particle.duration, delay: particle.delay, repeat: Infinity, ease: 'linear' }}
+                />
+            ))}
+        </div>
+    );
+}
+
 function OceanRainEffects() {
     return (
         <div className="fixed inset-0 pointer-events-none z-2 overflow-hidden" aria-hidden="true">
@@ -623,6 +662,7 @@ function OceanRainEffects() {
 
 function OceanBackdrop({ weather }: { weather: WeatherType }) {
     const isRain = weather === 'Rain';
+    const isSnow = weather === 'Snow';
     return (
         <>
             <div className="fixed inset-0 pointer-events-none z-0 bg-[#041116]" />
@@ -688,6 +728,7 @@ function OceanBackdrop({ weather }: { weather: WeatherType }) {
             ))}
 
             {isRain && <OceanRainEffects />}
+            {isSnow && <MarineSnow />}
 
             {fishSpecs.map((fish, index) => (
                 <motion.div
@@ -718,25 +759,31 @@ export default function DenshouoClient() {
     const router = useRouter();
     const searchParams = useSearchParams();
     const lang = searchParams.get('lang') === 'en' ? 'en' : 'ja';
-    const { setActiveWork, setWeather, weather } = useStore();
-    const weatherParam = searchParams.get('weather');
-    const displayedWeather = VALID_WEATHERS.includes(weatherParam as WeatherType)
-        ? weatherParam as WeatherType
-        : weather;
+    const { setActiveWork, setSeason, setSeasonEvent, setWeather, season, seasonEvent, weather } = useStore();
+    const routeWorldState = parseWorldStateParams(searchParams);
+    const displayedWeather = routeWorldState.weather ?? weather;
+    const displayedSeason = routeWorldState.season ?? season;
+    const displayedSeasonEvent = routeWorldState.seasonEvent ?? seasonEvent;
 
     useEffect(() => {
-        if (weatherParam && VALID_WEATHERS.includes(weatherParam as WeatherType)) {
-            const nextWeather = weatherParam as WeatherType;
-            if (weather !== nextWeather) setWeather(nextWeather);
-            return;
+        if (routeWorldState.weather && weather !== routeWorldState.weather) {
+            setWeather(routeWorldState.weather);
+        }
+        if (routeWorldState.season && season !== routeWorldState.season) {
+            setSeason(routeWorldState.season);
+        }
+        if (routeWorldState.seasonEvent && seasonEvent !== routeWorldState.seasonEvent) {
+            setSeasonEvent(routeWorldState.seasonEvent);
         }
 
-        if (weather !== 'Rain') return;
+        if (routeWorldState.weather || routeWorldState.season || routeWorldState.seasonEvent || weather !== 'Rain') return;
 
         const params = new URLSearchParams(searchParams.toString());
-        params.set('weather', 'Rain');
+        params.set('weather', weather);
+        params.set('season', season);
+        params.set('seasonEvent', seasonEvent);
         router.replace(`/denshouo?${params.toString()}`, { scroll: false });
-    }, [router, searchParams, setWeather, weather, weatherParam]);
+    }, [routeWorldState.season, routeWorldState.seasonEvent, routeWorldState.weather, router, searchParams, season, seasonEvent, setSeason, setSeasonEvent, setWeather, weather]);
 
     const [showBackdrop, setShowBackdrop] = useState(true);
     const [ripples, setRipples] = useState<Array<{ id: number; x: number; y: number; size: number; isHover: boolean }>>([]);
@@ -886,7 +933,7 @@ export default function DenshouoClient() {
 
     const handleReturn = () => {
         setActiveWork(null);
-        router.push(`/?lang=${lang}`);
+        router.push(`/?${buildWorldStateQuery({ weather: displayedWeather, season: displayedSeason, seasonEvent: displayedSeasonEvent }, lang)}`);
     };
 
     return (

--- a/src/app/denshouo/DenshouoClient.tsx
+++ b/src/app/denshouo/DenshouoClient.tsx
@@ -601,62 +601,23 @@ function OceanBubbles() {
 }
 
 function OceanRainEffects() {
-    const rainRippleSpecs = useMemo(
-        () => Array.from({ length: 12 }, (_, index) => {
-            const seeded = (salt: number) => {
-                const value = Math.sin(index * 12.9898 + salt * 78.233) * 43758.5453123;
-                return value - Math.floor(value);
-            };
-
-            return {
-                left: `${8 + seeded(1) * 84}%`,
-                top: `${14 + seeded(2) * 68}%`,
-                width: 42 + seeded(3) * 72,
-                height: 10 + seeded(4) * 12,
-                delay: seeded(5) * 6,
-                duration: 4.8 + seeded(6) * 3.4,
-            };
-        }),
-        []
-    );
-
     return (
-        <>
-            <div className="fixed inset-0 pointer-events-none z-2 overflow-hidden" aria-hidden="true">
-                {rainLightSpecs.map((light, index) => (
-                    <motion.div
-                        key={`rain-light-column-${index}`}
-                        className="absolute -top-[12%] h-[84%] rounded-full blur-2xl mix-blend-screen"
-                        style={{
-                            left: light.left,
-                            width: `${light.width}%`,
-                            transform: `rotate(${light.rotate}deg)`,
-                            background: 'linear-gradient(to bottom, rgba(95,196,220,0) 0%, rgba(95,196,220,0.08) 45%, rgba(147,205,255,0.025) 72%, rgba(95,196,220,0) 100%)',
-                        }}
-                        animate={{ opacity: [0.10, 0.28, 0.10], x: ['-2%', '2%', '-2%'] }}
-                        transition={{ duration: light.duration, delay: light.delay, repeat: Infinity, ease: 'easeInOut' }}
-                    />
-                ))}
-            </div>
-
-            <div className="fixed inset-0 pointer-events-none z-2 overflow-hidden" aria-hidden="true">
-                {rainRippleSpecs.map((ripple, index) => (
-                    <motion.div
-                        key={`rain-surface-ripple-${index}`}
-                        className="absolute rounded-[50%] border border-cyan-100/20"
-                        style={{
-                            left: ripple.left,
-                            top: ripple.top,
-                            width: ripple.width,
-                            height: ripple.height,
-                            boxShadow: '0 0 12px rgba(94,234,212,0.08)',
-                        }}
-                        animate={{ scale: [0.42, 1.0, 1.35], opacity: [0, 0.22, 0] }}
-                        transition={{ duration: ripple.duration, delay: ripple.delay, repeat: Infinity, ease: 'easeOut' }}
-                    />
-                ))}
-            </div>
-        </>
+        <div className="fixed inset-0 pointer-events-none z-2 overflow-hidden" aria-hidden="true">
+            {rainLightSpecs.map((light, index) => (
+                <motion.div
+                    key={`rain-light-column-${index}`}
+                    className="absolute -top-[12%] h-[84%] rounded-full blur-2xl mix-blend-screen"
+                    style={{
+                        left: light.left,
+                        width: `${light.width}%`,
+                        transform: `rotate(${light.rotate}deg)`,
+                        background: 'linear-gradient(to bottom, rgba(95,196,220,0) 0%, rgba(95,196,220,0.08) 45%, rgba(147,205,255,0.025) 72%, rgba(95,196,220,0) 100%)',
+                    }}
+                    animate={{ opacity: [0.10, 0.28, 0.10], x: ['-2%', '2%', '-2%'] }}
+                    transition={{ duration: light.duration, delay: light.delay, repeat: Infinity, ease: 'easeInOut' }}
+                />
+            ))}
+        </div>
     );
 }
 
@@ -762,6 +723,15 @@ export default function DenshouoClient() {
     const displayedWeather = VALID_WEATHERS.includes(weatherParam as WeatherType)
         ? weatherParam as WeatherType
         : weather;
+
+    useEffect(() => {
+        if (weather !== 'Rain' || weatherParam) return;
+
+        const params = new URLSearchParams(searchParams.toString());
+        params.set('weather', 'Rain');
+        router.replace(`/denshouo?${params.toString()}`, { scroll: false });
+    }, [router, searchParams, weather, weatherParam]);
+
     const [showBackdrop, setShowBackdrop] = useState(true);
     const [ripples, setRipples] = useState<Array<{ id: number; x: number; y: number; size: number; isHover: boolean }>>([]);
     const rippleIdRef = useRef(0);
@@ -816,6 +786,40 @@ export default function DenshouoClient() {
             window.clearTimeout(timer);
         };
     }, []);
+
+    useEffect(() => {
+        if (displayedWeather !== 'Rain') return;
+
+        let cancelled = false;
+        let timer = 0;
+
+        const scheduleRainRipple = () => {
+            timer = window.setTimeout(() => {
+                if (cancelled) return;
+
+                const id = rippleIdRef.current;
+                rippleIdRef.current += 1;
+                setRipples((current) => [
+                    ...current,
+                    {
+                        id,
+                        x: 8 + Math.random() * 84,
+                        y: 18 + Math.random() * 64,
+                        size: 82 + Math.random() * 26,
+                        isHover: true,
+                    },
+                ]);
+
+                scheduleRainRipple();
+            }, 2000 + Math.random() * 2200);
+        };
+
+        scheduleRainRipple();
+        return () => {
+            cancelled = true;
+            window.clearTimeout(timer);
+        };
+    }, [displayedWeather]);
 
 
 

--- a/src/app/otenkigurashi/OtenkiGurashiClient.tsx
+++ b/src/app/otenkigurashi/OtenkiGurashiClient.tsx
@@ -831,10 +831,19 @@ export default function OtenkiGurashiClient() {
         bgGradient = "from-[#fcedf3] via-[#fff5f9] to-[#fffdfd]";
     }
 
+    if (displayedSeason === 'autumn' && (displayedWeather === 'Clear' || displayedWeather === 'Morning')) {
+        bgGradient = "from-[#c7ded9] via-[#f1e6ce] to-[#e4b36f]";
+    }
+
+    if (displayedSeason === 'summer' && displayedSeasonEvent === 'geshi' && (displayedWeather === 'Clear' || displayedWeather === 'Morning')) {
+        bgGradient = "from-[#bddfeb] via-[#e0eef0] to-[#fff0cf]";
+    }
+
     const springCardStyle = displayedSeason === 'spring' && (displayedWeather === 'Clear' || displayedWeather === 'Morning')
         ? 'border-white shadow-[0_20px_60px_-15px_rgba(152,173,194,0.3)]'
         : 'border-white shadow-[0_20px_60px_-15px_rgba(152,173,194,0.3)]';
     const isSpringSun = displayedSeason === 'spring' && (displayedWeather === 'Clear' || displayedWeather === 'Morning');
+    const isGeshiSun = displayedSeason === 'summer' && displayedSeasonEvent === 'geshi' && (displayedWeather === 'Clear' || displayedWeather === 'Morning');
 
     return (
         <>
@@ -1008,8 +1017,12 @@ export default function OtenkiGurashiClient() {
                                         : 'radial-gradient(circle at 35% 35%, rgba(255,245,180,0.96) 0%, rgba(255,213,112,0.92) 38%, rgba(255,170,58,0.92) 100%)',
                                     boxShadow: isSpringSun
                                         ? '0 0 45px rgba(224,122,159,0.32), 0 0 110px rgba(205,100,139,0.16)'
+                                        : isGeshiSun
+                                            ? '0 0 28px rgba(150,211,240,0.22), 0 0 72px rgba(124,190,226,0.09)'
                                         : '0 0 45px rgba(255,205,110,0.55), 0 0 110px rgba(255,187,82,0.35)',
-                                    animation: 'sun-soft-pulse 4.6s ease-in-out infinite',
+                                    animation: isGeshiSun
+                                        ? 'geshi-sun-soft-pulse 4.6s ease-in-out infinite'
+                                        : 'sun-soft-pulse 4.6s ease-in-out infinite',
                                 }}
                             />
                             <div
@@ -1017,6 +1030,8 @@ export default function OtenkiGurashiClient() {
                                 style={{
                                     background: isSpringSun
                                         ? 'radial-gradient(circle, rgba(255,205,219,0.22) 0%, rgba(229,128,166,0.07) 42%, rgba(229,128,166,0.0) 74%)'
+                                        : isGeshiSun
+                                            ? 'radial-gradient(circle, rgba(185,228,246,0.13) 0%, rgba(145,207,235,0.035) 42%, rgba(145,207,235,0.0) 74%)'
                                         : 'radial-gradient(circle, rgba(255,220,150,0.36) 0%, rgba(255,220,150,0.08) 42%, rgba(255,220,150,0.0) 74%)',
                                     animation: 'sun-aura-spin 16s linear infinite',
                                 }}
@@ -1026,6 +1041,10 @@ export default function OtenkiGurashiClient() {
                         @keyframes sun-soft-pulse {
                             0%, 100% { transform: scale(1); opacity: 0.94; }
                             50% { transform: scale(1.05); opacity: 1; }
+                        }
+                        @keyframes geshi-sun-soft-pulse {
+                            0%, 100% { transform: scale(1); opacity: 0.84; }
+                            50% { transform: scale(1.035); opacity: 0.9; }
                         }
                         @keyframes sun-aura-spin {
                             from { transform: rotate(0deg); }

--- a/src/app/otenkigurashi/OtenkiGurashiClient.tsx
+++ b/src/app/otenkigurashi/OtenkiGurashiClient.tsx
@@ -2,6 +2,8 @@
 
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useStore, type SeasonEventType, type SeasonType, WeatherType } from '@/store';
+import { AUTUMN_BACKGROUND_GRADIENT, WINTER_BACKGROUND_GRADIENT } from '@/lib/otenkigurashiSeasonal';
+import { parseMoonPhaseOverride } from '@/lib/moonPhase';
 import { useEffect, useRef, useState } from 'react';
 import dynamicImport from 'next/dynamic';
 import Image from 'next/image';
@@ -13,6 +15,7 @@ const RainParticles = dynamicImport(
 );
 const SnowCanvas = dynamicImport(() => import('@/components/canvas/effects/SnowCanvas'), { ssr: false });
 const ThunderCanvas = dynamicImport(() => import('@/components/canvas/ThunderTransitionCanvas'), { ssr: false });
+const MoonPhase = dynamicImport(() => import('@/components/dom/MoonPhase'), { ssr: false });
 const OtenkiSeasonEffects = dynamicImport(() => import('./OtenkiSeasonEffects'), { ssr: false });
 const VALID_WEATHERS: WeatherType[] = ['Clear', 'Rain', 'Clouds', 'Snow', 'Night', 'Morning', 'Thunder'];
 
@@ -36,7 +39,7 @@ function CloudDecoration({ className, style, flip }: { className: string, style?
 // Reads weather from the Zustand store and draws a matching cursor motif.
 // Motifs: Cloud (bob+squish) / Sun+Morning (spinning rays) / Rain (teardrop)
 //         Snow (rotating snowflake) / Night (crescent moon) / Thunder (bolt)
-//         Spring + Clear/Morning swaps the sun for a five-petal sakura mark.
+//         Spring + Clear/Morning swaps the sun for sakura; Autumn + Clear/Morning uses a maple leaf.
 function WeatherCursor({ weatherOverride, seasonOverride }: { weatherOverride?: WeatherType; seasonOverride?: SeasonType } = {}) {
     const storeWeather = useStore((state) => state.weather);
     const storeSeason = useStore((state) => state.season);
@@ -57,6 +60,8 @@ function WeatherCursor({ weatherOverride, seasonOverride }: { weatherOverride?: 
         sunRot: 0,
         // Spring / Clear
         sakuraRot: 0,
+        // Autumn / Clear
+        momijiRot: 0,
         // Snow
         snowRot: 0,
         // Rain
@@ -223,6 +228,67 @@ function WeatherCursor({ weatherOverride, seasonOverride }: { weatherOverride?: 
             ctx.fill();
             ctx.beginPath();
             ctx.ellipse(14 - drift, 9, 1.5, 2.3, 0.5, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.restore();
+        };
+
+        //  MOMIJI — maple leaf with a warm amber palette for the autumn cursor
+        const drawMomiji = (t: number, momijiRot: number) => {
+            const pulse = 1 + Math.sin(t * 2.1) * 0.04;
+            ctx.save();
+            ctx.rotate(momijiRot);
+            ctx.scale(pulse, pulse);
+            ctx.shadowBlur = 7;
+            ctx.shadowColor = 'rgba(188,112,45,0.28)';
+
+            ctx.beginPath();
+            ctx.moveTo(0, -14);
+            ctx.quadraticCurveTo(1.4, -10.5, 2.8, -7.4);
+            ctx.quadraticCurveTo(5.8, -9.3, 8.5, -10.4);
+            ctx.quadraticCurveTo(7.6, -6.9, 6.4, -4.1);
+            ctx.quadraticCurveTo(10.5, -3.1, 13.8, -1.4);
+            ctx.quadraticCurveTo(10.1, 0.2, 6.8, 1.2);
+            ctx.quadraticCurveTo(8, 5.4, 8.8, 8.3);
+            ctx.quadraticCurveTo(4.2, 6.7, 1.8, 4.7);
+            ctx.quadraticCurveTo(1, 9, 1.2, 12.8);
+            ctx.quadraticCurveTo(0.3, 13.8, 0, 14.5);
+            ctx.quadraticCurveTo(-0.3, 13.8, -1.2, 12.8);
+            ctx.quadraticCurveTo(-1, 9, -1.8, 4.7);
+            ctx.quadraticCurveTo(-4.2, 6.7, -8.8, 8.3);
+            ctx.quadraticCurveTo(-8, 5.4, -6.8, 1.2);
+            ctx.quadraticCurveTo(-10.1, 0.2, -13.8, -1.4);
+            ctx.quadraticCurveTo(-10.5, -3.1, -6.4, -4.1);
+            ctx.quadraticCurveTo(-7.6, -6.9, -8.5, -10.4);
+            ctx.quadraticCurveTo(-5.8, -9.3, -2.8, -7.4);
+            ctx.quadraticCurveTo(-1.4, -10.5, 0, -14);
+            ctx.closePath();
+            const leaf = ctx.createLinearGradient(-8, -12, 8, 12);
+            leaf.addColorStop(0, '#ffd76f');
+            leaf.addColorStop(0.55, '#efa94d');
+            leaf.addColorStop(1, '#d8783e');
+            ctx.fillStyle = leaf;
+            ctx.fill();
+            ctx.strokeStyle = 'rgba(173,91,39,0.68)';
+            ctx.lineWidth = 0.9;
+            ctx.stroke();
+
+            ctx.shadowBlur = 0;
+            ctx.strokeStyle = 'rgba(255,224,137,0.76)';
+            ctx.lineWidth = 0.9;
+            ctx.lineCap = 'round';
+            ctx.beginPath();
+            ctx.moveTo(0, 11); ctx.lineTo(0, -7);
+            ctx.moveTo(0, 0); ctx.lineTo(-6, -4.5);
+            ctx.moveTo(0, 0); ctx.lineTo(6, -4.5);
+            ctx.stroke();
+
+            const drift = Math.sin(t * 1.7) * 1.6;
+            ctx.fillStyle = 'rgba(233,153,69,0.78)';
+            ctx.beginPath();
+            ctx.moveTo(-17 + drift, -8); ctx.lineTo(-14 + drift, -12); ctx.lineTo(-11 + drift, -8); ctx.lineTo(-14 + drift, -4); ctx.closePath();
+            ctx.fill();
+            ctx.beginPath();
+            ctx.moveTo(15 - drift, 8); ctx.lineTo(18 - drift, 4); ctx.lineTo(21 - drift, 8); ctx.lineTo(18 - drift, 12); ctx.closePath();
             ctx.fill();
             ctx.restore();
         };
@@ -526,7 +592,9 @@ function WeatherCursor({ weatherOverride, seasonOverride }: { weatherOverride?: 
             const speed = Math.hypot(s.vx, s.vy);
 
             // ── per-weather state update ────────────────────────────────────
-            const isSpringClear = seasonRef.current === 'spring' && (w === 'Clear' || w === 'Morning');
+            const isClearOrMorning = w === 'Clear' || w === 'Morning';
+            const isSpringClear = seasonRef.current === 'spring' && isClearOrMorning;
+            const isAutumnClear = seasonRef.current === 'autumn' && isClearOrMorning;
             if (w === 'Clouds') {
                 s.bobPhase += 0.038 * dt;
                 const tSqX = 1 + Math.min(speed * 0.013, 0.22);
@@ -537,6 +605,7 @@ function WeatherCursor({ weatherOverride, seasonOverride }: { weatherOverride?: 
             } else if (w === 'Clear' || w === 'Morning') {
                 s.sunRot += 0.018 * dt;
                 if (isSpringClear) s.sakuraRot += 0.012 * dt;
+                if (isAutumnClear) s.momijiRot += 0.009 * dt;
             } else if (w === 'Snow') {
                 s.snowRot += 0.012 * dt;
             } else if (w === 'Rain') {
@@ -589,6 +658,8 @@ function WeatherCursor({ weatherOverride, seasonOverride }: { weatherOverride?: 
             } else if (w === 'Clear' || w === 'Morning') {
                 if (isSpringClear) {
                     drawSakura(t, s.sakuraRot);
+                } else if (isAutumnClear) {
+                    drawMomiji(t, s.momijiRot);
                 } else {
                     drawSun(t, s.sunRot);
                 }
@@ -707,6 +778,7 @@ export default function OtenkiGurashiClient() {
     const seasonEventFromParam = validSeasonEvents.includes(seasonEventParam as SeasonEventType) ? seasonEventParam as SeasonEventType : null;
     const displayedSeason = seasonFromParam ?? storeSeason;
     const displayedSeasonEvent = seasonEventFromParam ?? storeSeasonEvent;
+    const moonPhaseOverride = parseMoonPhaseOverride(searchParams.get('moonPhase'));
 
     // スクロール検知用の状態とRef
     const [activeSection, setActiveSection] = useState<'hero' | 'concept' | 'features' | 'tech' | 'bottom'>('hero');
@@ -844,11 +916,20 @@ export default function OtenkiGurashiClient() {
         : 'border-white shadow-[0_20px_60px_-15px_rgba(152,173,194,0.3)]';
     const isSpringSun = displayedSeason === 'spring' && (displayedWeather === 'Clear' || displayedWeather === 'Morning');
     const isGeshiSun = displayedSeason === 'summer' && displayedSeasonEvent === 'geshi' && (displayedWeather === 'Clear' || displayedWeather === 'Morning');
+    const isWinterSnowScene = displayedSeason === 'winter'
+        && (displayedWeather === 'Clear' || displayedWeather === 'Morning' || displayedWeather === 'Snow');
 
     return (
         <>
             <WeatherCursor weatherOverride={displayedWeather} seasonOverride={displayedSeason} />
-            <main className={`relative w-full min-h-[120dvh] ${displayedWeather !== 'Rain' && displayedWeather !== 'Snow' ? 'bg-gradient-to-b' : ''} ${bgGradient} ${displayedWeather === 'Thunder' || displayedWeather === 'Night' ? 'text-gray-200' : 'text-gray-700'} overflow-hidden font-sans pb-32 transition-colors duration-1000`} style={{ cursor: isFinePointer ? 'none' : 'auto' }}>
+            <main className={`relative w-full min-h-[120dvh] ${displayedWeather !== 'Rain' && displayedWeather !== 'Snow' ? 'bg-gradient-to-b' : ''} ${bgGradient} ${displayedWeather === 'Thunder' || displayedWeather === 'Night' ? 'text-gray-200' : 'text-gray-700'} overflow-hidden font-sans pb-32 transition-colors duration-1000`} style={{
+                cursor: isFinePointer ? 'none' : 'auto',
+                background: displayedSeason === 'autumn' && (displayedWeather === 'Clear' || displayedWeather === 'Morning')
+                    ? AUTUMN_BACKGROUND_GRADIENT
+                    : isWinterSnowScene
+                        ? WINTER_BACKGROUND_GRADIENT
+                    : undefined,
+            }}>
                 <OtenkiSeasonEffects season={displayedSeason} seasonEvent={displayedSeasonEvent} weather={displayedWeather} />
 
                 <nav className="fixed top-0 left-0 w-full z-50 p-6 md:p-10">
@@ -1013,10 +1094,10 @@ export default function OtenkiGurashiClient() {
                                 className="absolute right-[8%] top-[9%] w-24 h-24 md:w-32 md:h-32 rounded-full"
                                 style={{
                                     background: isSpringSun
-                                        ? 'radial-gradient(circle at 35% 35%, rgba(255,244,214,0.98) 0%, rgba(241,157,188,0.96) 38%, rgba(205,100,139,0.94) 100%)'
+                                        ? 'radial-gradient(circle at 35% 35%, rgba(255,248,214,0.98) 0%, rgba(255,218,133,0.92) 38%, rgba(242,176,76,0.88) 100%)'
                                         : 'radial-gradient(circle at 35% 35%, rgba(255,245,180,0.96) 0%, rgba(255,213,112,0.92) 38%, rgba(255,170,58,0.92) 100%)',
                                     boxShadow: isSpringSun
-                                        ? '0 0 45px rgba(224,122,159,0.32), 0 0 110px rgba(205,100,139,0.16)'
+                                        ? '0 0 45px rgba(247,190,101,0.28), 0 0 110px rgba(236,163,80,0.12)'
                                         : isGeshiSun
                                             ? '0 0 28px rgba(150,211,240,0.22), 0 0 72px rgba(124,190,226,0.09)'
                                         : '0 0 45px rgba(255,205,110,0.55), 0 0 110px rgba(255,187,82,0.35)',
@@ -1029,7 +1110,7 @@ export default function OtenkiGurashiClient() {
                                 className="absolute right-[3%] top-[2%] w-44 h-44 md:w-64 md:h-64 rounded-full"
                                 style={{
                                     background: isSpringSun
-                                        ? 'radial-gradient(circle, rgba(255,205,219,0.22) 0%, rgba(229,128,166,0.07) 42%, rgba(229,128,166,0.0) 74%)'
+                                        ? 'radial-gradient(circle, rgba(255,224,157,0.20) 0%, rgba(245,183,97,0.06) 42%, rgba(245,183,97,0.0) 74%)'
                                         : isGeshiSun
                                             ? 'radial-gradient(circle, rgba(185,228,246,0.13) 0%, rgba(145,207,235,0.035) 42%, rgba(145,207,235,0.0) 74%)'
                                         : 'radial-gradient(circle, rgba(255,220,150,0.36) 0%, rgba(255,220,150,0.08) 42%, rgba(255,220,150,0.0) 74%)',
@@ -1086,8 +1167,10 @@ export default function OtenkiGurashiClient() {
                             }} />
 
                             {/* 右上の三日月 */}
-                            <div className="absolute right-[10%] top-[10%] w-24 h-24 md:w-32 md:h-32 rounded-full bg-[#dce8ff] opacity-90 shadow-[0_0_35px_rgba(167,196,245,0.38)]" />
-                            <div className="absolute right-[7.7%] top-[8.6%] w-24 h-24 md:w-32 md:h-32 rounded-full bg-[#081325] opacity-95" />
+                            <MoonPhase
+                                phaseOverride={moonPhaseOverride}
+                                className="absolute right-[10%] top-[10%] w-24 h-24 md:w-32 md:h-32 opacity-90"
+                            />
 
                             {/* 小さな星 */}
                             <div className="absolute inset-0 opacity-60" style={{
@@ -1116,6 +1199,9 @@ export default function OtenkiGurashiClient() {
                         section={activeSection}
                         weather={displayedWeather}
                         showUmbrella={false}
+                        showSakura={isSpringSun}
+                        showMomiji={displayedSeason === 'autumn' && (displayedWeather === 'Clear' || displayedWeather === 'Morning')}
+                        showSnowflake={displayedSeason === 'winter' && displayedWeather === 'Snow'}
                         overrideDialog={overrideDialog}
                         onClick={handleTenchanClick}
                     />

--- a/src/app/otenkigurashi/OtenkiGurashiClient.tsx
+++ b/src/app/otenkigurashi/OtenkiGurashiClient.tsx
@@ -1,9 +1,18 @@
 'use client'
 
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useStore, type SeasonEventType, type SeasonType, WeatherType } from '@/store';
-import { AUTUMN_BACKGROUND_GRADIENT, WINTER_BACKGROUND_GRADIENT } from '@/lib/otenkigurashiSeasonal';
+import { useStore, type SeasonType, WeatherType } from '@/store';
+import {
+    AUTUMN_BACKGROUND_GRADIENT,
+    SPRING_FLOWER_CLOUDY_BACKGROUND_GRADIENT,
+    TSUYU_CLEAR_BACKGROUND_GRADIENT,
+    TSUYU_CLOUDS_BACKGROUND_GRADIENT,
+    TSUYU_RAIN_BACKGROUND_GRADIENT,
+    WINTER_BACKGROUND_GRADIENT,
+} from '@/lib/otenkigurashiSeasonal';
 import { parseMoonPhaseOverride } from '@/lib/moonPhase';
+import { resolveSeasonState } from '@/lib/seasonResolver';
+import { buildWorldStateQuery, parseWorldStateParams } from '@/lib/worldState';
 import { useEffect, useRef, useState } from 'react';
 import dynamicImport from 'next/dynamic';
 import Image from 'next/image';
@@ -17,8 +26,6 @@ const SnowCanvas = dynamicImport(() => import('@/components/canvas/effects/SnowC
 const ThunderCanvas = dynamicImport(() => import('@/components/canvas/ThunderTransitionCanvas'), { ssr: false });
 const MoonPhase = dynamicImport(() => import('@/components/dom/MoonPhase'), { ssr: false });
 const OtenkiSeasonEffects = dynamicImport(() => import('./OtenkiSeasonEffects'), { ssr: false });
-const VALID_WEATHERS: WeatherType[] = ['Clear', 'Rain', 'Clouds', 'Snow', 'Night', 'Morning', 'Thunder'];
-
 // A simple CSS cloud decoration component
 function CloudDecoration({ className, style, flip }: { className: string, style?: React.CSSProperties, flip?: boolean }) {
     return (
@@ -705,10 +712,9 @@ export default function OtenkiGurashiClient() {
         season: storeSeason,
         seasonEvent: storeSeasonEvent,
     } = useStore();
-    const weatherParam = searchParams.get('weather');
-    const seasonParam = searchParams.get('season');
-    const seasonEventParam = searchParams.get('seasonEvent');
-    const weatherFromParam = VALID_WEATHERS.includes(weatherParam as WeatherType) ? weatherParam as WeatherType : null;
+    const routeWorldState = parseWorldStateParams(searchParams);
+    const resolvedSeasonState = resolveSeasonState();
+    const weatherFromParam = routeWorldState.weather;
     const displayedWeather = weatherFromParam ?? weather;
 
     const copy = {
@@ -772,12 +778,10 @@ export default function OtenkiGurashiClient() {
         },
     } as const;
     const t = copy[lang];
-    const validSeasons: SeasonType[] = ['none', 'spring', 'summer', 'autumn', 'winter'];
-    const validSeasonEvents: SeasonEventType[] = ['none', 'geshi'];
-    const seasonFromParam = validSeasons.includes(seasonParam as SeasonType) ? seasonParam as SeasonType : null;
-    const seasonEventFromParam = validSeasonEvents.includes(seasonEventParam as SeasonEventType) ? seasonEventParam as SeasonEventType : null;
-    const displayedSeason = seasonFromParam ?? storeSeason;
-    const displayedSeasonEvent = seasonEventFromParam ?? storeSeasonEvent;
+    const seasonFromParam = routeWorldState.season;
+    const seasonEventFromParam = routeWorldState.seasonEvent;
+    const displayedSeason = seasonFromParam ?? (storeSeason === 'none' ? resolvedSeasonState.season : storeSeason);
+    const displayedSeasonEvent = seasonEventFromParam ?? (storeSeasonEvent === 'none' ? resolvedSeasonState.seasonEvent : storeSeasonEvent);
     const moonPhaseOverride = parseMoonPhaseOverride(searchParams.get('moonPhase'));
 
     // スクロール検知用の状態とRef
@@ -879,7 +883,7 @@ export default function OtenkiGurashiClient() {
 
     const handleReturn = () => {
         setActiveWork(null); // ワープ状態をリセット
-        router.push(`/?lang=${lang}`);
+        router.push(`/?${buildWorldStateQuery({ weather: displayedWeather, season: displayedSeason, seasonEvent: displayedSeasonEvent }, lang)}`);
     };
 
     let bgGradient = "from-[#aee1f9] to-[#e0f4fc]"; // Default (Clear)
@@ -903,6 +907,10 @@ export default function OtenkiGurashiClient() {
         bgGradient = "from-[#fcedf3] via-[#fff5f9] to-[#fffdfd]";
     }
 
+    if (displayedSeason === 'spring' && displayedWeather === 'Clouds') {
+        bgGradient = "from-[#c5d1d9] via-[#e6e9e7] to-[#f3e8ed]";
+    }
+
     if (displayedSeason === 'autumn' && (displayedWeather === 'Clear' || displayedWeather === 'Morning')) {
         bgGradient = "from-[#c7ded9] via-[#f1e6ce] to-[#e4b36f]";
     }
@@ -911,13 +919,24 @@ export default function OtenkiGurashiClient() {
         bgGradient = "from-[#bddfeb] via-[#e0eef0] to-[#fff0cf]";
     }
 
+    if (displayedSeasonEvent === 'tsuyu') {
+        bgGradient = displayedWeather === 'Rain'
+            ? TSUYU_RAIN_BACKGROUND_GRADIENT
+            : displayedWeather === 'Clouds'
+                ? TSUYU_CLOUDS_BACKGROUND_GRADIENT
+                : displayedWeather === 'Clear' || displayedWeather === 'Morning'
+                    ? TSUYU_CLEAR_BACKGROUND_GRADIENT
+                    : bgGradient;
+    }
+
     const springCardStyle = displayedSeason === 'spring' && (displayedWeather === 'Clear' || displayedWeather === 'Morning')
         ? 'border-white shadow-[0_20px_60px_-15px_rgba(152,173,194,0.3)]'
         : 'border-white shadow-[0_20px_60px_-15px_rgba(152,173,194,0.3)]';
     const isSpringSun = displayedSeason === 'spring' && (displayedWeather === 'Clear' || displayedWeather === 'Morning');
+    const isFlowerCloudy = displayedSeason === 'spring' && displayedWeather === 'Clouds';
     const isGeshiSun = displayedSeason === 'summer' && displayedSeasonEvent === 'geshi' && (displayedWeather === 'Clear' || displayedWeather === 'Morning');
-    const isWinterSnowScene = displayedSeason === 'winter'
-        && (displayedWeather === 'Clear' || displayedWeather === 'Morning' || displayedWeather === 'Snow');
+    const isTsuyu = displayedSeasonEvent === 'tsuyu';
+    const isWinterSnowScene = displayedSeason === 'winter' && displayedWeather === 'Snow';
 
     return (
         <>
@@ -926,6 +945,14 @@ export default function OtenkiGurashiClient() {
                 cursor: isFinePointer ? 'none' : 'auto',
                 background: displayedSeason === 'autumn' && (displayedWeather === 'Clear' || displayedWeather === 'Morning')
                     ? AUTUMN_BACKGROUND_GRADIENT
+                    : isTsuyu && (displayedWeather === 'Clear' || displayedWeather === 'Morning')
+                        ? TSUYU_CLEAR_BACKGROUND_GRADIENT
+                    : isTsuyu && displayedWeather === 'Clouds'
+                        ? TSUYU_CLOUDS_BACKGROUND_GRADIENT
+                    : isTsuyu && displayedWeather === 'Rain'
+                        ? TSUYU_RAIN_BACKGROUND_GRADIENT
+                    : isFlowerCloudy
+                        ? SPRING_FLOWER_CLOUDY_BACKGROUND_GRADIENT
                     : isWinterSnowScene
                         ? WINTER_BACKGROUND_GRADIENT
                     : undefined,
@@ -1199,9 +1226,12 @@ export default function OtenkiGurashiClient() {
                         section={activeSection}
                         weather={displayedWeather}
                         showUmbrella={false}
-                        showSakura={isSpringSun}
+                        showSakura={isSpringSun || isFlowerCloudy}
                         showMomiji={displayedSeason === 'autumn' && (displayedWeather === 'Clear' || displayedWeather === 'Morning')}
-                        showSnowflake={displayedSeason === 'winter' && displayedWeather === 'Snow'}
+                        showSnowflake={displayedWeather === 'Snow'}
+                        showRainDrop={displayedWeather === 'Rain'}
+                        showLightning={displayedWeather === 'Thunder'}
+                        showNightStar={displayedWeather === 'Night'}
                         overrideDialog={overrideDialog}
                         onClick={handleTenchanClick}
                     />

--- a/src/app/otenkigurashi/OtenkiSeasonEffects.tsx
+++ b/src/app/otenkigurashi/OtenkiSeasonEffects.tsx
@@ -1,6 +1,10 @@
 'use client'
 
 import { type SeasonEventType, type SeasonType, type WeatherType } from '@/store';
+import {
+    AUTUMN_LEAF_SPECS,
+    autumnLeafStyle,
+} from '@/lib/otenkigurashiSeasonal';
 import { useMemo } from 'react';
 
 const seasonalValue = (index: number, salt: number) => {
@@ -21,8 +25,7 @@ export default function OtenkiSeasonEffects({
     const showSpring = season === 'spring' && isClear;
     const showGeshi = season === 'summer' && isClear && seasonEvent === 'geshi';
     const showSummer = season === 'summer' && isClear && !showGeshi;
-    const showAutumn = season === 'autumn';
-    const showAutumnLeaves = showAutumn && isClear;
+    const showAutumn = season === 'autumn' && isClear;
     const showWinter = season === 'winter';
     const springPetals = useMemo(
         () => Array.from({ length: 24 }, (_, index) => ({
@@ -37,19 +40,6 @@ export default function OtenkiSeasonEffects({
         })),
         []
     );
-    const autumnLeaves = useMemo(
-        () => Array.from({ length: 20 }, (_, index) => ({
-            left: seasonalValue(index, 11) * 100,
-            duration: 9 + seasonalValue(index, 13) * 7,
-            delay: -(seasonalValue(index, 12) * (9 + seasonalValue(index, 13) * 7)),
-            size: 13 + seasonalValue(index, 14) * 11,
-            drift: -42 + seasonalValue(index, 15) * 84,
-            rotate: seasonalValue(index, 16) * 360,
-            tone: seasonalValue(index, 17),
-        })),
-        []
-    );
-
     if (!showSpring && !showSummer && !showGeshi && !showAutumn && !showWinter) return null;
 
     return (
@@ -76,28 +66,13 @@ export default function OtenkiSeasonEffects({
                 />
             ))}
 
-            {showAutumnLeaves && autumnLeaves.map((leaf, index) => (
+            {showAutumn && AUTUMN_LEAF_SPECS.map((leaf, index) => (
                 <span
                     key={`otenki-momiji-${index}`}
                     className="absolute"
                     style={{
-                        left: `${leaf.left}%`,
-                        top: '-8%',
-                        width: leaf.size,
-                        height: leaf.size * 0.92,
-                        display: 'block',
-                        clipPath: 'polygon(50% 2%, 57% 34%, 79% 20%, 67% 47%, 93% 48%, 68% 62%, 70% 91%, 51% 71%, 32% 93%, 34% 64%, 8% 69%, 31% 49%, 19% 25%, 43% 34%)',
-                        background: leaf.tone > 0.6
-                            ? 'linear-gradient(135deg, rgba(224,96,40,0.90), rgba(143,48,28,0.72))'
-                            : leaf.tone > 0.28
-                                ? 'linear-gradient(135deg, rgba(238,156,39,0.88), rgba(181,81,30,0.68))'
-                                : 'linear-gradient(135deg, rgba(247,191,54,0.86), rgba(194,105,30,0.64))',
-                        filter: 'drop-shadow(0 2px 3px rgba(105,55,29,0.18))',
-                        transform: `rotate(${leaf.rotate}deg)`,
-                        opacity: 0.86,
+                        ...autumnLeafStyle(leaf),
                         zIndex: 30,
-                        animation: `otenki-autumn-fall ${leaf.duration}s linear ${leaf.delay}s infinite`,
-                        ['--autumn-drift' as string]: `${leaf.drift}px`,
                     }}
                 >
                     <span
@@ -107,7 +82,7 @@ export default function OtenkiSeasonEffects({
                 </span>
             ))}
 
-            {showAutumnLeaves && <div className="absolute inset-x-0 bottom-0 z-20 h-[14%] otenki-momiji-ground" />}
+            {showAutumn && <div className="absolute inset-x-0 bottom-0 z-20 h-[14%] otenki-momiji-ground" />}
 
             {showSummer && <div className="absolute inset-0 otenki-season-summer" />}
 
@@ -173,18 +148,18 @@ export default function OtenkiSeasonEffects({
 
                 .otenki-season-autumn {
                     background:
-                        radial-gradient(ellipse at 12% 84%, rgba(224,133,47,0.34) 0%, transparent 42%),
-                        linear-gradient(116deg, rgba(255,194,101,0.24), transparent 42%, rgba(104,47,30,0.16)),
-                        radial-gradient(ellipse at 50% 50%, transparent 42%, rgba(111,50,29,0.16) 100%);
+                        radial-gradient(ellipse at 12% 84%, rgba(232,155,61,0.24) 0%, transparent 42%),
+                        linear-gradient(116deg, rgba(255,209,123,0.18), transparent 42%, rgba(150,93,61,0.08)),
+                        radial-gradient(ellipse at 50% 50%, transparent 42%, rgba(144,87,61,0.08) 100%);
                     mix-blend-mode: normal;
                     animation: otenki-autumn-light 12s ease-in-out infinite alternate;
                 }
 
                 .otenki-momiji-ground {
                     background:
-                        radial-gradient(ellipse at 12% 100%, rgba(177,71,29,0.34) 0%, transparent 34%),
-                        radial-gradient(ellipse at 52% 112%, rgba(222,145,38,0.32) 0%, transparent 44%),
-                        linear-gradient(to top, rgba(130,65,28,0.18), transparent 72%);
+                        radial-gradient(ellipse at 12% 100%, rgba(194,108,55,0.20) 0%, transparent 34%),
+                        radial-gradient(ellipse at 52% 112%, rgba(235,168,61,0.24) 0%, transparent 44%),
+                        linear-gradient(to top, rgba(161,98,57,0.10), transparent 72%);
                     filter: blur(1px);
                     opacity: 0.78;
                 }
@@ -215,7 +190,7 @@ export default function OtenkiSeasonEffects({
                     }
                 }
 
-                @keyframes otenki-autumn-fall {
+                @keyframes otenki-momiji-fall {
                     0% {
                         transform: translate3d(0, -10vh, 0) rotate(0deg);
                         opacity: 0;

--- a/src/app/otenkigurashi/OtenkiSeasonEffects.tsx
+++ b/src/app/otenkigurashi/OtenkiSeasonEffects.tsx
@@ -19,9 +19,10 @@ export default function OtenkiSeasonEffects({
 }) {
     const isClear = weather === 'Clear' || weather === 'Morning';
     const showSpring = season === 'spring' && isClear;
-    const showSummer = season === 'summer' && isClear;
-    const showGeshi = showSummer && seasonEvent === 'geshi';
+    const showGeshi = season === 'summer' && isClear && seasonEvent === 'geshi';
+    const showSummer = season === 'summer' && isClear && !showGeshi;
     const showAutumn = season === 'autumn';
+    const showAutumnLeaves = showAutumn && isClear;
     const showWinter = season === 'winter';
     const springPetals = useMemo(
         () => Array.from({ length: 24 }, (_, index) => ({
@@ -37,11 +38,11 @@ export default function OtenkiSeasonEffects({
         []
     );
     const autumnLeaves = useMemo(
-        () => Array.from({ length: 14 }, (_, index) => ({
+        () => Array.from({ length: 20 }, (_, index) => ({
             left: seasonalValue(index, 11) * 100,
-            delay: seasonalValue(index, 12) * 8,
-            duration: 12 + seasonalValue(index, 13) * 8,
-            size: 9 + seasonalValue(index, 14) * 8,
+            duration: 9 + seasonalValue(index, 13) * 7,
+            delay: -(seasonalValue(index, 12) * (9 + seasonalValue(index, 13) * 7)),
+            size: 13 + seasonalValue(index, 14) * 11,
             drift: -42 + seasonalValue(index, 15) * 84,
             rotate: seasonalValue(index, 16) * 360,
             tone: seasonalValue(index, 17),
@@ -49,7 +50,7 @@ export default function OtenkiSeasonEffects({
         []
     );
 
-    if (!showSpring && !showSummer && !showAutumn && !showWinter) return null;
+    if (!showSpring && !showSummer && !showGeshi && !showAutumn && !showWinter) return null;
 
     return (
         <div className="fixed inset-0 pointer-events-none z-10 overflow-hidden" aria-hidden="true">
@@ -75,7 +76,7 @@ export default function OtenkiSeasonEffects({
                 />
             ))}
 
-            {showAutumn && autumnLeaves.map((leaf, index) => (
+            {showAutumnLeaves && autumnLeaves.map((leaf, index) => (
                 <span
                     key={`otenki-momiji-${index}`}
                     className="absolute"
@@ -83,23 +84,40 @@ export default function OtenkiSeasonEffects({
                         left: `${leaf.left}%`,
                         top: '-8%',
                         width: leaf.size,
-                        height: leaf.size * 0.72,
-                        borderRadius: '70% 30% 70% 30%',
+                        height: leaf.size * 0.92,
+                        display: 'block',
+                        clipPath: 'polygon(50% 2%, 57% 34%, 79% 20%, 67% 47%, 93% 48%, 68% 62%, 70% 91%, 51% 71%, 32% 93%, 34% 64%, 8% 69%, 31% 49%, 19% 25%, 43% 34%)',
                         background: leaf.tone > 0.6
-                            ? 'linear-gradient(135deg, rgba(220,121,48,0.82), rgba(150,76,31,0.52))'
-                            : 'linear-gradient(135deg, rgba(236,178,67,0.78), rgba(184,104,38,0.50))',
+                            ? 'linear-gradient(135deg, rgba(224,96,40,0.90), rgba(143,48,28,0.72))'
+                            : leaf.tone > 0.28
+                                ? 'linear-gradient(135deg, rgba(238,156,39,0.88), rgba(181,81,30,0.68))'
+                                : 'linear-gradient(135deg, rgba(247,191,54,0.86), rgba(194,105,30,0.64))',
+                        filter: 'drop-shadow(0 2px 3px rgba(105,55,29,0.18))',
                         transform: `rotate(${leaf.rotate}deg)`,
-                        opacity: 0.54,
+                        opacity: 0.86,
                         zIndex: 30,
                         animation: `otenki-autumn-fall ${leaf.duration}s linear ${leaf.delay}s infinite`,
                         ['--autumn-drift' as string]: `${leaf.drift}px`,
                     }}
-                />
+                >
+                    <span
+                        className="absolute left-1/2 top-[14%] h-[72%] w-px -translate-x-1/2 rotate-[8deg] bg-amber-100/45"
+                        aria-hidden="true"
+                    />
+                </span>
             ))}
+
+            {showAutumnLeaves && <div className="absolute inset-x-0 bottom-0 z-20 h-[14%] otenki-momiji-ground" />}
 
             {showSummer && <div className="absolute inset-0 otenki-season-summer" />}
 
-            {showGeshi && <div className="absolute inset-0 otenki-season-geshi" />}
+            {showGeshi && (
+                <>
+                    <div className="absolute inset-0 otenki-season-geshi" />
+                    <div className="absolute inset-0 otenki-season-geshi-rays" />
+                    <div className="absolute inset-0 otenki-season-geshi-longday" />
+                </>
+            )}
 
             {showAutumn && <div className="absolute inset-0 otenki-season-autumn" />}
 
@@ -126,18 +144,49 @@ export default function OtenkiSeasonEffects({
 
                 .otenki-season-geshi {
                     background:
-                        radial-gradient(circle at 82% 10%, rgba(255,237,148,0.30) 0%, transparent 34%),
-                        linear-gradient(to bottom, rgba(255,245,193,0.13), transparent 58%);
+                        radial-gradient(circle at 82% 10%, rgba(202,231,236,0.16) 0%, rgba(170,215,226,0.035) 27%, transparent 40%),
+                        linear-gradient(to bottom, rgba(238,239,216,0.055), transparent 58%);
                     animation: otenki-sun-breathe 4s ease-in-out infinite alternate;
+                }
+
+                .otenki-season-geshi-rays {
+                    background: repeating-conic-gradient(
+                        from 198deg at 82% 10%,
+                        rgba(220,243,251,0.09) 0deg 3deg,
+                        transparent 3deg 15deg
+                    );
+                    mask-image: linear-gradient(to bottom, #000 0%, rgba(0,0,0,0.72) 34%, transparent 76%);
+                    mix-blend-mode: screen;
+                    opacity: 0.24;
+                    transform-origin: 82% 10%;
+                    animation: otenki-geshi-rays 15s ease-in-out infinite alternate;
+                }
+
+                .otenki-season-geshi-longday {
+                    background:
+                        linear-gradient(174deg, rgba(219,242,251,0.07) 0%, transparent 32%),
+                        radial-gradient(ellipse at 50% 100%, rgba(169,220,241,0.07) 0%, transparent 58%);
+                    mix-blend-mode: soft-light;
+                    opacity: 0.46;
+                    animation: otenki-geshi-longday 11s ease-in-out infinite alternate;
                 }
 
                 .otenki-season-autumn {
                     background:
-                        radial-gradient(ellipse at 12% 84%, rgba(224,133,47,0.44) 0%, transparent 42%),
-                        linear-gradient(116deg, rgba(255,194,101,0.30), transparent 42%, rgba(104,47,30,0.24)),
-                        radial-gradient(ellipse at 50% 50%, transparent 42%, rgba(111,50,29,0.24) 100%);
+                        radial-gradient(ellipse at 12% 84%, rgba(224,133,47,0.34) 0%, transparent 42%),
+                        linear-gradient(116deg, rgba(255,194,101,0.24), transparent 42%, rgba(104,47,30,0.16)),
+                        radial-gradient(ellipse at 50% 50%, transparent 42%, rgba(111,50,29,0.16) 100%);
                     mix-blend-mode: normal;
                     animation: otenki-autumn-light 12s ease-in-out infinite alternate;
+                }
+
+                .otenki-momiji-ground {
+                    background:
+                        radial-gradient(ellipse at 12% 100%, rgba(177,71,29,0.34) 0%, transparent 34%),
+                        radial-gradient(ellipse at 52% 112%, rgba(222,145,38,0.32) 0%, transparent 44%),
+                        linear-gradient(to top, rgba(130,65,28,0.18), transparent 72%);
+                    filter: blur(1px);
+                    opacity: 0.78;
                 }
 
                 .otenki-season-winter {
@@ -171,7 +220,7 @@ export default function OtenkiSeasonEffects({
                         transform: translate3d(0, -10vh, 0) rotate(0deg);
                         opacity: 0;
                     }
-                    12% { opacity: 0.54; }
+                    12% { opacity: 0.86; }
                     100% {
                         transform: translate3d(var(--autumn-drift), 112vh, 0) rotate(460deg);
                         opacity: 0;
@@ -184,8 +233,18 @@ export default function OtenkiSeasonEffects({
                 }
 
                 @keyframes otenki-sun-breathe {
-                    from { opacity: 0.58; transform: scale(1); }
-                    to { opacity: 0.96; transform: scale(1.04); }
+                    from { opacity: 0.46; transform: scale(1); }
+                    to { opacity: 0.72; transform: scale(1.04); }
+                }
+
+                @keyframes otenki-geshi-rays {
+                    from { transform: rotate(-1deg) scale(1.02); opacity: 0.16; }
+                    to { transform: rotate(2deg) scale(1.08); opacity: 0.30; }
+                }
+
+                @keyframes otenki-geshi-longday {
+                    from { transform: translate3d(-1%, 0, 0) scale(1.02); opacity: 0.32; }
+                    to { transform: translate3d(1%, -0.5%, 0) scale(1.06); opacity: 0.52; }
                 }
 
                 @keyframes otenki-autumn-light {

--- a/src/app/otenkigurashi/OtenkiSeasonEffects.tsx
+++ b/src/app/otenkigurashi/OtenkiSeasonEffects.tsx
@@ -24,7 +24,7 @@ export default function OtenkiSeasonEffects({
     weather: WeatherType;
 }) {
     const isClear = weather === 'Clear' || weather === 'Morning';
-    const showTsuyu = seasonEvent === 'tsuyu' && (isClear || weather === 'Clouds' || weather === 'Rain');
+    const showTsuyu = season === 'summer' && seasonEvent === 'tsuyu' && (isClear || weather === 'Clouds' || weather === 'Rain');
     const showSpring = season === 'spring' && isClear && !showTsuyu;
     const showFlowerCloudy = season === 'spring' && weather === 'Clouds' && !showTsuyu;
     const showGeshi = season === 'summer' && isClear && seasonEvent === 'geshi';

--- a/src/app/otenkigurashi/OtenkiSeasonEffects.tsx
+++ b/src/app/otenkigurashi/OtenkiSeasonEffects.tsx
@@ -4,6 +4,8 @@ import { type SeasonEventType, type SeasonType, type WeatherType } from '@/store
 import {
     AUTUMN_LEAF_SPECS,
     autumnLeafStyle,
+    FLOWER_CLOUDY_PETAL_SPECS,
+    TSUYU_ATMOSPHERE_GRADIENT,
 } from '@/lib/otenkigurashiSeasonal';
 import { useMemo } from 'react';
 
@@ -22,11 +24,13 @@ export default function OtenkiSeasonEffects({
     weather: WeatherType;
 }) {
     const isClear = weather === 'Clear' || weather === 'Morning';
-    const showSpring = season === 'spring' && isClear;
+    const showTsuyu = seasonEvent === 'tsuyu' && (isClear || weather === 'Clouds' || weather === 'Rain');
+    const showSpring = season === 'spring' && isClear && !showTsuyu;
+    const showFlowerCloudy = season === 'spring' && weather === 'Clouds' && !showTsuyu;
     const showGeshi = season === 'summer' && isClear && seasonEvent === 'geshi';
-    const showSummer = season === 'summer' && isClear && !showGeshi;
-    const showAutumn = season === 'autumn' && isClear;
-    const showWinter = season === 'winter';
+    const showSummer = season === 'summer' && isClear && !showGeshi && !showTsuyu;
+    const showAutumn = season === 'autumn' && isClear && !showTsuyu;
+    const showWinter = season === 'winter' && weather === 'Snow' && !showTsuyu;
     const springPetals = useMemo(
         () => Array.from({ length: 24 }, (_, index) => ({
             left: seasonalValue(index, 1) * 100,
@@ -40,11 +44,20 @@ export default function OtenkiSeasonEffects({
         })),
         []
     );
-    if (!showSpring && !showSummer && !showGeshi && !showAutumn && !showWinter) return null;
+    if (!showTsuyu && !showSpring && !showFlowerCloudy && !showSummer && !showGeshi && !showAutumn && !showWinter) return null;
 
     return (
         <div className="fixed inset-0 pointer-events-none z-10 overflow-hidden" aria-hidden="true">
+            {showTsuyu && (
+                <>
+                    <div data-testid="tsuyu-atmosphere" className="absolute inset-0 otenki-season-tsuyu" />
+                    <div className={`absolute inset-0 otenki-season-tsuyu-${weather === 'Clouds' ? 'clouds' : weather === 'Rain' ? 'rain' : 'clear'}`} />
+                </>
+            )}
+
             {showSpring && <div className="absolute inset-0 otenki-season-spring" />}
+
+            {showFlowerCloudy && <div className="absolute inset-0 otenki-season-flower-cloudy" />}
 
             {showSpring && springPetals.map((petal, index) => (
                 <span
@@ -59,6 +72,26 @@ export default function OtenkiSeasonEffects({
                         boxShadow: '0 0 8px rgba(255,180,211,0.30)',
                         transform: `rotate(${petal.rotate}deg)`,
                         opacity: 0.68,
+                        zIndex: 30,
+                        animation: `otenki-sakura-fall ${petal.duration}s linear ${petal.delay}s infinite`,
+                        ['--sakura-drift' as string]: `${petal.drift}px`,
+                    }}
+                />
+            ))}
+
+            {showFlowerCloudy && FLOWER_CLOUDY_PETAL_SPECS.map((petal, index) => (
+                <span
+                    key={`otenki-flower-cloudy-petal-${index}`}
+                    className="absolute rounded-[70%_30%_70%_30%]"
+                    style={{
+                        left: `${petal.left}%`,
+                        top: '-8%',
+                        width: petal.size * 0.82,
+                        height: petal.size * 0.5,
+                        background: 'linear-gradient(135deg, rgba(255,250,252,0.74), rgba(232,170,195,0.42))',
+                        boxShadow: '0 0 6px rgba(248,193,214,0.16)',
+                        transform: `rotate(${petal.rotate}deg)`,
+                        opacity: 0.36,
                         zIndex: 30,
                         animation: `otenki-sakura-fall ${petal.duration}s linear ${petal.delay}s infinite`,
                         ['--sakura-drift' as string]: `${petal.drift}px`,
@@ -105,6 +138,36 @@ export default function OtenkiSeasonEffects({
                         linear-gradient(155deg, rgba(255,255,255,0.04), transparent 58%);
                     mix-blend-mode: normal;
                     animation: otenki-spring-breeze 10s ease-in-out infinite alternate;
+                }
+
+                .otenki-season-tsuyu {
+                    background: ${TSUYU_ATMOSPHERE_GRADIENT};
+                    mix-blend-mode: normal;
+                    opacity: 0.82;
+                    animation: otenki-tsuyu-air 10s ease-in-out infinite alternate;
+                }
+
+                .otenki-season-tsuyu-clear {
+                    background: radial-gradient(ellipse at 72% 12%, rgba(217,239,247,0.22), transparent 42%), linear-gradient(180deg, rgba(129,165,202,0.04), transparent 72%);
+                    opacity: 0.70;
+                }
+
+                .otenki-season-tsuyu-clouds {
+                    background: radial-gradient(ellipse at 50% 8%, rgba(210,220,232,0.20), transparent 54%), linear-gradient(180deg, rgba(113,139,175,0.12), rgba(121,101,151,0.06));
+                    opacity: 0.82;
+                }
+
+                .otenki-season-tsuyu-rain {
+                    background: radial-gradient(ellipse at 50% 35%, rgba(164,198,226,0.16), transparent 56%), repeating-linear-gradient(112deg, transparent 0 28px, rgba(180,205,229,0.035) 31px 33px, transparent 36px 66px);
+                    opacity: 0.78;
+                }
+
+                .otenki-season-flower-cloudy {
+                    background:
+                        radial-gradient(ellipse at 18% 12%, rgba(255,255,255,0.22) 0%, transparent 38%),
+                        linear-gradient(160deg, rgba(255,255,255,0.06), rgba(244,205,220,0.07) 68%, rgba(244,205,220,0.12));
+                    mix-blend-mode: normal;
+                    animation: otenki-flower-cloudy-haze 12s ease-in-out infinite alternate;
                 }
 
                 .otenki-season-summer {
@@ -176,6 +239,16 @@ export default function OtenkiSeasonEffects({
                 @keyframes otenki-spring-breeze {
                     from { transform: translate3d(-1.5%, 0, 0) scale(1.02); opacity: 0.68; }
                     to { transform: translate3d(1.5%, 1%, 0) scale(1.05); opacity: 0.92; }
+                }
+
+                @keyframes otenki-tsuyu-air {
+                    from { transform: translate3d(-0.5%, 0, 0) scale(1.02); opacity: 0.64; }
+                    to { transform: translate3d(0.5%, 0.5%, 0) scale(1.05); opacity: 0.86; }
+                }
+
+                @keyframes otenki-flower-cloudy-haze {
+                    from { transform: translate3d(-0.6%, 0, 0) scale(1.02); opacity: 0.66; }
+                    to { transform: translate3d(0.6%, 0.5%, 0) scale(1.04); opacity: 0.86; }
                 }
 
                 @keyframes otenki-sakura-fall {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,12 +7,16 @@ import WeatherDebugSelector from '@/components/dom/WeatherDebugSelector';
 import NomineeToast from '@/components/dom/NomineeToast';
 import TopLeftMenu from '../components/dom/TopLeftMenu';
 import Link from 'next/link';
-import type { WeatherType } from '@/store';
+import type { SeasonEventType, SeasonType, WeatherType } from '@/store';
+import { parseWorldStateRecord } from '@/lib/worldState';
 
 type SupportedLang = 'ja' | 'en';
 
 type SearchParams = {
   lang?: string | string[];
+  weather?: string | string[];
+  season?: string | string[];
+  seasonEvent?: string | string[];
 };
 
 const copyByLang = {
@@ -101,8 +105,12 @@ export default async function Home({
     ? resolvedSearchParams.lang[0]
     : resolvedSearchParams.lang;
   const lang: SupportedLang = langParam === 'en' ? 'en' : 'ja';
+  const routeWorldState = parseWorldStateRecord(resolvedSearchParams);
+  const initialWeather = routeWorldState.weather ?? data.weather;
+  const initialSeason = routeWorldState.season ?? data.season;
+  const initialSeasonEvent = routeWorldState.seasonEvent ?? data.seasonEvent;
   const t = copyByLang[lang];
-  const hudWeatherLabel = data.weather === 'Morning' ? 'CLEAR' : data.weather.toUpperCase();
+  const hudWeatherLabel = initialWeather === 'Morning' ? 'CLEAR' : initialWeather.toUpperCase();
 
   const works = t.works.map((work) => ({ ...work }));
 
@@ -112,7 +120,9 @@ export default async function Home({
       style={{ userSelect: 'none', WebkitUserSelect: 'none', WebkitTouchCallout: 'none' }}
     >
       <ClientInitializer
-        initialWeather={data.weather as WeatherType}
+        initialWeather={initialWeather as WeatherType}
+        initialSeason={initialSeason as SeasonType}
+        initialSeasonEvent={initialSeasonEvent as SeasonEventType}
         initialActivity={data.activityLevel}
       />
 
@@ -145,7 +155,7 @@ export default async function Home({
               </div>
               <div className="flex gap-4">
                 <span className="w-12">WTHR</span>
-                <span className={data.weather === 'Rain' ? 'text-blue-400' : 'text-orange-400'}>
+                <span className={initialWeather === 'Rain' ? 'text-blue-400' : 'text-orange-400'}>
                   {hudWeatherLabel}
                 </span>
               </div>

--- a/src/components/ClientInitializer.tsx
+++ b/src/components/ClientInitializer.tsx
@@ -1,22 +1,28 @@
 'use client'
 
 import { useEffect } from 'react';
-import { useStore, WeatherType } from '@/store';
+import { useStore, type SeasonEventType, type SeasonType, type WeatherType } from '@/store';
 
 export default function ClientInitializer({
     initialWeather,
+    initialSeason,
+    initialSeasonEvent,
     initialActivity
 }: {
     initialWeather: WeatherType;
+    initialSeason?: SeasonType;
+    initialSeasonEvent?: SeasonEventType;
     initialActivity: number;
 }) {
-    const { setWeather, setActivity, setActiveWork } = useStore();
+    const { setWeather, setSeason, setSeasonEvent, setActivity, setActiveWork } = useStore();
 
     useEffect(() => {
         setWeather(initialWeather);
+        if (initialSeason) setSeason(initialSeason);
+        if (initialSeasonEvent) setSeasonEvent(initialSeasonEvent);
         setActivity(initialActivity);
         setActiveWork(null);
-    }, [initialWeather, initialActivity, setWeather, setActivity, setActiveWork]);
+    }, [initialActivity, initialSeason, initialSeasonEvent, initialWeather, setActiveWork, setActivity, setSeason, setSeasonEvent, setWeather]);
 
     return null;
 }

--- a/src/components/GlobalTransitionOverlay.tsx
+++ b/src/components/GlobalTransitionOverlay.tsx
@@ -24,6 +24,8 @@ const seasonalValue = (index: number, salt: number) => {
 };
 
 function SeasonalTransitionAtmosphere({ season, seasonEvent }: { season: SeasonType; seasonEvent: SeasonEventType }) {
+    const weather = useStore((state) => state.weather);
+    const showAutumnLeaves = season === 'autumn' && (weather === 'Clear' || weather === 'Morning');
     const springPetals = useMemo(
         () => Array.from({ length: 18 }, (_, index) => ({
             left: seasonalValue(index, 21) * 100,
@@ -35,18 +37,32 @@ function SeasonalTransitionAtmosphere({ season, seasonEvent }: { season: SeasonT
         })),
         []
     );
+    const autumnLeaves = useMemo(
+        () => Array.from({ length: 18 }, (_, index) => ({
+            left: seasonalValue(index, 31) * 100,
+            duration: 9 + seasonalValue(index, 33) * 7,
+            delay: -(seasonalValue(index, 32) * (9 + seasonalValue(index, 33) * 7)),
+            size: 12 + seasonalValue(index, 34) * 9,
+            drift: -34 + seasonalValue(index, 35) * 68,
+            rotate: seasonalValue(index, 36) * 360,
+            tone: seasonalValue(index, 37),
+        })),
+        []
+    );
 
     if (season === 'none') return null;
+
+    const isGeshi = season === 'summer' && seasonEvent === 'geshi';
 
     const backgroundBySeason: Record<SeasonType, string> = {
         none: 'transparent',
         spring: 'radial-gradient(ellipse at 18% 12%, rgba(255,255,255,0.20), transparent 48%)',
-        summer: 'radial-gradient(ellipse at 82% 8%, rgba(255,220,115,0.42), transparent 48%), linear-gradient(180deg, rgba(255,201,79,0.12), transparent 62%)',
-        autumn: 'radial-gradient(ellipse at 15% 84%, rgba(237,148,54,0.36), transparent 46%), linear-gradient(115deg, rgba(255,190,93,0.18), transparent 62%)',
+        summer: isGeshi
+            ? 'radial-gradient(ellipse at 82% 8%, rgba(181,224,243,0.18), transparent 48%), linear-gradient(180deg, rgba(160,211,235,0.08), transparent 62%)'
+            : 'radial-gradient(ellipse at 82% 8%, rgba(255,220,115,0.42), transparent 48%), linear-gradient(180deg, rgba(255,201,79,0.12), transparent 62%)',
+        autumn: 'linear-gradient(180deg, #c7ded9 0%, #f1e6ce 50%, #e4b36f 100%)',
         winter: 'linear-gradient(110deg, rgba(193,228,249,0.28), transparent 34%, transparent 68%, rgba(175,215,242,0.24)), radial-gradient(ellipse at 50% 100%, rgba(255,255,255,0.34), transparent 65%)',
     };
-
-    const isGeshi = season === 'summer' && seasonEvent === 'geshi';
 
     return (
         <motion.div
@@ -54,11 +70,18 @@ function SeasonalTransitionAtmosphere({ season, seasonEvent }: { season: SeasonT
             className="fixed inset-0 z-[10000] pointer-events-none overflow-hidden"
             style={{
                 background: backgroundBySeason[season],
-                mixBlendMode: season === 'autumn' ? 'multiply' : 'normal',
+                mixBlendMode: 'normal',
                 boxShadow: season === 'winter' ? 'inset 0 0 80px rgba(199,230,249,0.36)' : undefined,
             }}
             initial={{ opacity: 0, scale: 1.04 }}
-            animate={{ opacity: isGeshi ? [0.18, 0.36, 0.24] : [0.10, 0.20, 0.14], scale: [1.04, 1, 1.02] }}
+            animate={{
+                opacity: season === 'autumn'
+                    ? [0.34, 0.58, 0.44]
+                    : isGeshi
+                        ? [0.18, 0.36, 0.24]
+                        : [0.10, 0.20, 0.14],
+                scale: [1.04, 1, 1.02],
+            }}
             exit={{ opacity: 0, scale: 1.06 }}
             transition={{ duration: 1.15, ease: [0.22, 1, 0.36, 1] }}
         >
@@ -80,11 +103,35 @@ function SeasonalTransitionAtmosphere({ season, seasonEvent }: { season: SeasonT
                     }}
                 />
             ))}
+            {showAutumnLeaves && autumnLeaves.map((leaf, index) => (
+                <span
+                    key={`transition-momiji-leaf-${index}`}
+                    className="absolute"
+                    style={{
+                        left: `${leaf.left}%`,
+                        top: '-8%',
+                        width: leaf.size,
+                        height: leaf.size * 0.92,
+                        clipPath: 'polygon(50% 2%, 57% 34%, 79% 20%, 67% 47%, 93% 48%, 68% 62%, 70% 91%, 51% 71%, 32% 93%, 34% 64%, 8% 69%, 31% 49%, 19% 25%, 43% 34%)',
+                        background: 'linear-gradient(135deg, rgba(247,191,54,0.86), rgba(194,105,30,0.64))',
+                        filter: 'drop-shadow(0 2px 3px rgba(105,55,29,0.16))',
+                        transform: `rotate(${leaf.rotate}deg)`,
+                        opacity: 0.92,
+                        animation: `otenki-transition-momiji-fall ${leaf.duration}s linear ${leaf.delay}s infinite`,
+                        ['--transition-momiji-drift' as string]: `${leaf.drift}px`,
+                    }}
+                />
+            ))}
             <style>{`
                 @keyframes otenki-transition-sakura-fall {
                     0% { transform: translate3d(0, -10vh, 0) rotate(0deg); opacity: 0; }
                     14% { opacity: 0.74; }
                     100% { transform: translate3d(var(--transition-sakura-drift), 116vh, 0) rotate(420deg); opacity: 0; }
+                }
+                @keyframes otenki-transition-momiji-fall {
+                    0% { transform: translate3d(0, -10vh, 0) rotate(0deg); opacity: 0; }
+                    12% { opacity: 0.86; }
+                    100% { transform: translate3d(var(--transition-momiji-drift), 116vh, 0) rotate(400deg); opacity: 0; }
                 }
             `}</style>
         </motion.div>

--- a/src/components/GlobalTransitionOverlay.tsx
+++ b/src/components/GlobalTransitionOverlay.tsx
@@ -1,14 +1,19 @@
 'use client';
 
-import { useStore, type SeasonEventType, type SeasonType } from '@/store';
+import { useStore, type SeasonEventType, type SeasonType, type WeatherType } from '@/store';
 import { useEffect, useMemo } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
 import { AnimatePresence, motion } from 'framer-motion';
 import dynamic from 'next/dynamic';
 import {
     AUTUMN_BACKGROUND_GRADIENT,
     AUTUMN_LEAF_SPECS,
     autumnLeafStyle,
+    FLOWER_CLOUDY_PETAL_SPECS,
+    SPRING_FLOWER_CLOUDY_BACKGROUND_GRADIENT,
+    TSUYU_ATMOSPHERE_GRADIENT,
 } from '@/lib/otenkigurashiSeasonal';
+import { VALID_SEASON_EVENTS, VALID_SEASONS, VALID_WEATHERS } from '@/lib/worldState';
 
 // Lazy load all transition canvases — only loaded when triggered
 const WarpEffectCanvas = dynamic(() => import('@/components/canvas/WarpEffectCanvas'), { ssr: false });
@@ -28,11 +33,13 @@ const seasonalValue = (index: number, salt: number) => {
     return value - Math.floor(value);
 };
 
-function SeasonalTransitionAtmosphere({ season, seasonEvent }: { season: SeasonType; seasonEvent: SeasonEventType }) {
-    const weather = useStore((state) => state.weather);
+function SeasonalTransitionAtmosphere({ season, seasonEvent, weather }: { season: SeasonType; seasonEvent: SeasonEventType; weather: WeatherType }) {
     const isClear = weather === 'Clear' || weather === 'Morning';
     const showSpring = season === 'spring' && isClear;
+    const showFlowerCloudy = season === 'spring' && weather === 'Clouds';
     const showAutumn = season === 'autumn' && isClear;
+    const showWinterSnow = season === 'winter' && weather === 'Snow';
+    const showTsuyu = seasonEvent === 'tsuyu' && (isClear || weather === 'Clouds' || weather === 'Rain');
     const springPetals = useMemo(
         () => Array.from({ length: 18 }, (_, index) => ({
             left: seasonalValue(index, 21) * 100,
@@ -52,6 +59,8 @@ function SeasonalTransitionAtmosphere({ season, seasonEvent }: { season: SeasonT
         none: 'transparent',
         spring: showSpring
             ? 'radial-gradient(ellipse at 18% 12%, rgba(255,255,255,0.20), transparent 48%)'
+            : showFlowerCloudy
+                ? SPRING_FLOWER_CLOUDY_BACKGROUND_GRADIENT
             : 'transparent',
         summer: !isClear
             ? 'transparent'
@@ -59,7 +68,9 @@ function SeasonalTransitionAtmosphere({ season, seasonEvent }: { season: SeasonT
             ? 'radial-gradient(ellipse at 82% 8%, rgba(181,224,243,0.18), transparent 48%), linear-gradient(180deg, rgba(160,211,235,0.08), transparent 62%)'
             : 'radial-gradient(ellipse at 82% 8%, rgba(255,220,115,0.42), transparent 48%), linear-gradient(180deg, rgba(255,201,79,0.12), transparent 62%)',
         autumn: showAutumn ? AUTUMN_BACKGROUND_GRADIENT : 'transparent',
-        winter: 'linear-gradient(110deg, rgba(193,228,249,0.28), transparent 34%, transparent 68%, rgba(175,215,242,0.24)), radial-gradient(ellipse at 50% 100%, rgba(255,255,255,0.34), transparent 65%)',
+        winter: showWinterSnow
+            ? 'linear-gradient(110deg, rgba(193,228,249,0.28), transparent 34%, transparent 68%, rgba(175,215,242,0.24)), radial-gradient(ellipse at 50% 100%, rgba(255,255,255,0.34), transparent 65%)'
+            : 'transparent',
     };
 
     return (
@@ -67,14 +78,18 @@ function SeasonalTransitionAtmosphere({ season, seasonEvent }: { season: SeasonT
             key={`season-atmosphere-${season}-${seasonEvent}`}
             className="fixed inset-0 z-[10000] pointer-events-none overflow-hidden"
             style={{
-                background: backgroundBySeason[season],
+                background: showTsuyu ? TSUYU_ATMOSPHERE_GRADIENT : backgroundBySeason[season],
                 mixBlendMode: 'normal',
-                boxShadow: season === 'winter' ? 'inset 0 0 80px rgba(199,230,249,0.36)' : undefined,
+                boxShadow: showWinterSnow ? 'inset 0 0 80px rgba(199,230,249,0.36)' : undefined,
             }}
             initial={{ opacity: 0, scale: 1.04 }}
             animate={{
-                opacity: showAutumn
+                opacity: showTsuyu
+                    ? [0.12, 0.24, 0.16]
+                    : showAutumn
                     ? [0.34, 0.58, 0.44]
+                    : showFlowerCloudy
+                        ? [0.06, 0.14, 0.10]
                     : isGeshi
                         ? [0.18, 0.36, 0.24]
                         : [0.10, 0.20, 0.14],
@@ -83,6 +98,30 @@ function SeasonalTransitionAtmosphere({ season, seasonEvent }: { season: SeasonT
             exit={{ opacity: 0, scale: 1.06 }}
             transition={{ duration: 1.15, ease: [0.22, 1, 0.36, 1] }}
         >
+            {showTsuyu && (
+                <>
+                    <div
+                        className="absolute inset-0"
+                        style={{
+                            background: weather === 'Clouds'
+                                ? 'radial-gradient(ellipse at 50% 8%, rgba(215,224,236,0.18), transparent 54%), linear-gradient(180deg, rgba(113,139,175,0.10), rgba(121,101,151,0.06))'
+                                : weather === 'Rain'
+                                    ? 'radial-gradient(ellipse at 50% 35%, rgba(164,198,226,0.14), transparent 56%)'
+                                    : 'radial-gradient(ellipse at 72% 12%, rgba(217,239,247,0.20), transparent 42%)',
+                            opacity: 0.82,
+                        }}
+                    />
+                    <div
+                        className="absolute inset-0"
+                        style={{
+                            background: 'linear-gradient(105deg, transparent 0%, rgba(162,177,211,0.08) 48%, transparent 76%)',
+                            filter: 'blur(12px)',
+                            animation: 'otenki-transition-tsuyu-air 8s ease-in-out infinite alternate',
+                        }}
+                    />
+                </>
+            )}
+
             {showSpring && springPetals.map((petal, index) => (
                 <span
                     key={`transition-sakura-petal-${index}`}
@@ -96,6 +135,24 @@ function SeasonalTransitionAtmosphere({ season, seasonEvent }: { season: SeasonT
                         boxShadow: '0 0 8px rgba(255,180,211,0.34)',
                         transform: `rotate(${petal.rotate}deg)`,
                         opacity: 0.74,
+                        animation: `otenki-transition-sakura-fall ${petal.duration}s linear ${petal.delay}s infinite`,
+                        ['--transition-sakura-drift' as string]: `${petal.drift}px`,
+                    }}
+                />
+            ))}
+            {showFlowerCloudy && FLOWER_CLOUDY_PETAL_SPECS.map((petal, index) => (
+                <span
+                    key={`transition-flower-cloudy-petal-${index}`}
+                    className="absolute rounded-[70%_30%_70%_30%]"
+                    style={{
+                        left: `${petal.left}%`,
+                        top: '-8%',
+                        width: petal.size * 0.82,
+                        height: petal.size * 0.5,
+                        background: 'linear-gradient(135deg, rgba(255,250,252,0.78), rgba(232,170,195,0.44))',
+                        boxShadow: '0 0 6px rgba(248,193,214,0.16)',
+                        transform: `rotate(${petal.rotate}deg)`,
+                        opacity: 0.38,
                         animation: `otenki-transition-sakura-fall ${petal.duration}s linear ${petal.delay}s infinite`,
                         ['--transition-sakura-drift' as string]: `${petal.drift}px`,
                     }}
@@ -116,13 +173,17 @@ function SeasonalTransitionAtmosphere({ season, seasonEvent }: { season: SeasonT
             <style>{`
                 @keyframes otenki-transition-sakura-fall {
                     0% { transform: translate3d(0, -10vh, 0) rotate(0deg); opacity: 0; }
-                    14% { opacity: 0.74; }
-                    100% { transform: translate3d(var(--transition-sakura-drift), 116vh, 0) rotate(420deg); opacity: 0; }
+                    12% { opacity: 0.68; }
+                    100% { transform: translate3d(var(--transition-sakura-drift), 112vh, 0) rotate(460deg); opacity: 0; }
                 }
                 @keyframes otenki-momiji-fall {
                     0% { transform: translate3d(0, -10vh, 0) rotate(0deg); opacity: 0; }
                     12% { opacity: 0.86; }
                     100% { transform: translate3d(var(--autumn-drift), 112vh, 0) rotate(460deg); opacity: 0; }
+                }
+                @keyframes otenki-transition-tsuyu-air {
+                    from { transform: translate3d(-1%, 0, 0) scale(1.02); opacity: 0.34; }
+                    to { transform: translate3d(1%, 0.5%, 0) scale(1.06); opacity: 0.72; }
                 }
             `}</style>
         </motion.div>
@@ -131,6 +192,21 @@ function SeasonalTransitionAtmosphere({ season, seasonEvent }: { season: SeasonT
 
 export default function GlobalTransitionOverlay() {
     const { transitionType, season, seasonEvent, setTransitionType } = useStore();
+    const storeWeather = useStore((state) => state.weather);
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+    const routeWeather = searchParams.get('weather');
+    const routeSeason = searchParams.get('season');
+    const routeSeasonEvent = searchParams.get('seasonEvent');
+    const effectiveWeather = pathname === '/otenkigurashi' && VALID_WEATHERS.includes(routeWeather as WeatherType)
+        ? routeWeather as WeatherType
+        : storeWeather;
+    const effectiveSeason = pathname === '/otenkigurashi' && VALID_SEASONS.includes(routeSeason as SeasonType)
+        ? routeSeason as SeasonType
+        : season;
+    const effectiveSeasonEvent = pathname === '/otenkigurashi' && VALID_SEASON_EVENTS.includes(routeSeasonEvent as SeasonEventType)
+        ? routeSeasonEvent as SeasonEventType
+        : seasonEvent;
     const isWeatherTransition = ['rain', 'snow', 'sunburst', 'flash', 'heavy-cloud', 'moonrise'].includes(transitionType);
 
     useEffect(() => {
@@ -308,7 +384,7 @@ export default function GlobalTransitionOverlay() {
             )}
 
             {isWeatherTransition && (
-                <SeasonalTransitionAtmosphere season={season} seasonEvent={seasonEvent} />
+                <SeasonalTransitionAtmosphere season={effectiveSeason} seasonEvent={effectiveSeasonEvent} weather={effectiveWeather} />
             )}
         </AnimatePresence>
     );

--- a/src/components/GlobalTransitionOverlay.tsx
+++ b/src/components/GlobalTransitionOverlay.tsx
@@ -4,6 +4,11 @@ import { useStore, type SeasonEventType, type SeasonType } from '@/store';
 import { useEffect, useMemo } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import dynamic from 'next/dynamic';
+import {
+    AUTUMN_BACKGROUND_GRADIENT,
+    AUTUMN_LEAF_SPECS,
+    autumnLeafStyle,
+} from '@/lib/otenkigurashiSeasonal';
 
 // Lazy load all transition canvases — only loaded when triggered
 const WarpEffectCanvas = dynamic(() => import('@/components/canvas/WarpEffectCanvas'), { ssr: false });
@@ -25,7 +30,9 @@ const seasonalValue = (index: number, salt: number) => {
 
 function SeasonalTransitionAtmosphere({ season, seasonEvent }: { season: SeasonType; seasonEvent: SeasonEventType }) {
     const weather = useStore((state) => state.weather);
-    const showAutumnLeaves = season === 'autumn' && (weather === 'Clear' || weather === 'Morning');
+    const isClear = weather === 'Clear' || weather === 'Morning';
+    const showSpring = season === 'spring' && isClear;
+    const showAutumn = season === 'autumn' && isClear;
     const springPetals = useMemo(
         () => Array.from({ length: 18 }, (_, index) => ({
             left: seasonalValue(index, 21) * 100,
@@ -37,30 +44,21 @@ function SeasonalTransitionAtmosphere({ season, seasonEvent }: { season: SeasonT
         })),
         []
     );
-    const autumnLeaves = useMemo(
-        () => Array.from({ length: 18 }, (_, index) => ({
-            left: seasonalValue(index, 31) * 100,
-            duration: 9 + seasonalValue(index, 33) * 7,
-            delay: -(seasonalValue(index, 32) * (9 + seasonalValue(index, 33) * 7)),
-            size: 12 + seasonalValue(index, 34) * 9,
-            drift: -34 + seasonalValue(index, 35) * 68,
-            rotate: seasonalValue(index, 36) * 360,
-            tone: seasonalValue(index, 37),
-        })),
-        []
-    );
-
     if (season === 'none') return null;
 
     const isGeshi = season === 'summer' && seasonEvent === 'geshi';
 
     const backgroundBySeason: Record<SeasonType, string> = {
         none: 'transparent',
-        spring: 'radial-gradient(ellipse at 18% 12%, rgba(255,255,255,0.20), transparent 48%)',
-        summer: isGeshi
+        spring: showSpring
+            ? 'radial-gradient(ellipse at 18% 12%, rgba(255,255,255,0.20), transparent 48%)'
+            : 'transparent',
+        summer: !isClear
+            ? 'transparent'
+            : isGeshi
             ? 'radial-gradient(ellipse at 82% 8%, rgba(181,224,243,0.18), transparent 48%), linear-gradient(180deg, rgba(160,211,235,0.08), transparent 62%)'
             : 'radial-gradient(ellipse at 82% 8%, rgba(255,220,115,0.42), transparent 48%), linear-gradient(180deg, rgba(255,201,79,0.12), transparent 62%)',
-        autumn: 'linear-gradient(180deg, #c7ded9 0%, #f1e6ce 50%, #e4b36f 100%)',
+        autumn: showAutumn ? AUTUMN_BACKGROUND_GRADIENT : 'transparent',
         winter: 'linear-gradient(110deg, rgba(193,228,249,0.28), transparent 34%, transparent 68%, rgba(175,215,242,0.24)), radial-gradient(ellipse at 50% 100%, rgba(255,255,255,0.34), transparent 65%)',
     };
 
@@ -75,7 +73,7 @@ function SeasonalTransitionAtmosphere({ season, seasonEvent }: { season: SeasonT
             }}
             initial={{ opacity: 0, scale: 1.04 }}
             animate={{
-                opacity: season === 'autumn'
+                opacity: showAutumn
                     ? [0.34, 0.58, 0.44]
                     : isGeshi
                         ? [0.18, 0.36, 0.24]
@@ -85,7 +83,7 @@ function SeasonalTransitionAtmosphere({ season, seasonEvent }: { season: SeasonT
             exit={{ opacity: 0, scale: 1.06 }}
             transition={{ duration: 1.15, ease: [0.22, 1, 0.36, 1] }}
         >
-            {season === 'spring' && springPetals.map((petal, index) => (
+            {showSpring && springPetals.map((petal, index) => (
                 <span
                     key={`transition-sakura-petal-${index}`}
                     className="absolute rounded-[70%_30%_70%_30%]"
@@ -103,24 +101,17 @@ function SeasonalTransitionAtmosphere({ season, seasonEvent }: { season: SeasonT
                     }}
                 />
             ))}
-            {showAutumnLeaves && autumnLeaves.map((leaf, index) => (
+            {showAutumn && AUTUMN_LEAF_SPECS.map((leaf, index) => (
                 <span
                     key={`transition-momiji-leaf-${index}`}
                     className="absolute"
-                    style={{
-                        left: `${leaf.left}%`,
-                        top: '-8%',
-                        width: leaf.size,
-                        height: leaf.size * 0.92,
-                        clipPath: 'polygon(50% 2%, 57% 34%, 79% 20%, 67% 47%, 93% 48%, 68% 62%, 70% 91%, 51% 71%, 32% 93%, 34% 64%, 8% 69%, 31% 49%, 19% 25%, 43% 34%)',
-                        background: 'linear-gradient(135deg, rgba(247,191,54,0.86), rgba(194,105,30,0.64))',
-                        filter: 'drop-shadow(0 2px 3px rgba(105,55,29,0.16))',
-                        transform: `rotate(${leaf.rotate}deg)`,
-                        opacity: 0.92,
-                        animation: `otenki-transition-momiji-fall ${leaf.duration}s linear ${leaf.delay}s infinite`,
-                        ['--transition-momiji-drift' as string]: `${leaf.drift}px`,
-                    }}
-                />
+                    style={{ ...autumnLeafStyle(leaf), zIndex: 30 }}
+                >
+                    <span
+                        className="absolute left-1/2 top-[14%] h-[72%] w-px -translate-x-1/2 rotate-[8deg] bg-amber-100/45"
+                        aria-hidden="true"
+                    />
+                </span>
             ))}
             <style>{`
                 @keyframes otenki-transition-sakura-fall {
@@ -128,10 +119,10 @@ function SeasonalTransitionAtmosphere({ season, seasonEvent }: { season: SeasonT
                     14% { opacity: 0.74; }
                     100% { transform: translate3d(var(--transition-sakura-drift), 116vh, 0) rotate(420deg); opacity: 0; }
                 }
-                @keyframes otenki-transition-momiji-fall {
+                @keyframes otenki-momiji-fall {
                     0% { transform: translate3d(0, -10vh, 0) rotate(0deg); opacity: 0; }
                     12% { opacity: 0.86; }
-                    100% { transform: translate3d(var(--transition-momiji-drift), 116vh, 0) rotate(400deg); opacity: 0; }
+                    100% { transform: translate3d(var(--autumn-drift), 112vh, 0) rotate(460deg); opacity: 0; }
                 }
             `}</style>
         </motion.div>

--- a/src/components/GlobalTransitionOverlay.tsx
+++ b/src/components/GlobalTransitionOverlay.tsx
@@ -39,7 +39,7 @@ function SeasonalTransitionAtmosphere({ season, seasonEvent, weather }: { season
     const showFlowerCloudy = season === 'spring' && weather === 'Clouds';
     const showAutumn = season === 'autumn' && isClear;
     const showWinterSnow = season === 'winter' && weather === 'Snow';
-    const showTsuyu = seasonEvent === 'tsuyu' && (isClear || weather === 'Clouds' || weather === 'Rain');
+    const showTsuyu = season === 'summer' && seasonEvent === 'tsuyu' && (isClear || weather === 'Clouds' || weather === 'Rain');
     const springPetals = useMemo(
         () => Array.from({ length: 18 }, (_, index) => ({
             left: seasonalValue(index, 21) * 100,

--- a/src/components/TenchanCompanion.tsx
+++ b/src/components/TenchanCompanion.tsx
@@ -9,13 +9,19 @@ type CharacterFaceProps = {
     petColor?: string;
     cheekColor?: string;
     isStatic?: boolean;
+    showSakura?: boolean;
+    showMomiji?: boolean;
+    showSnowflake?: boolean;
 };
 
 export function CharacterFace({
     mood = "happy",
     petColor = "white",
     cheekColor = "#F8BBD0",
-    isStatic = false
+    isStatic = false,
+    showSakura = false,
+    showMomiji = false,
+    showSnowflake = false,
 }: CharacterFaceProps) {
 
     const getMouthPath = () => {
@@ -75,6 +81,42 @@ export function CharacterFace({
                     fill={isRainbow ? '#ff0000' : safePetColor}
                     animate={isStatic ? undefined : (isRainbow ? rainbowAnimation : { fill: safePetColor })}
                 />
+
+                {showSakura && (
+                    <g transform="translate(86 16) rotate(12)" aria-hidden="true">
+                        <ellipse cx="0" cy="-5" rx="3.8" ry="5" fill="#f5a9c4" stroke="#e58dab" strokeWidth="0.8" />
+                        <ellipse cx="4.8" cy="-1.5" rx="3.8" ry="5" transform="rotate(72 4.8 -1.5)" fill="#f7b6cc" stroke="#e58dab" strokeWidth="0.8" />
+                        <ellipse cx="3" cy="4.3" rx="3.8" ry="5" transform="rotate(144 3 4.3)" fill="#f5a9c4" stroke="#e58dab" strokeWidth="0.8" />
+                        <ellipse cx="-3" cy="4.3" rx="3.8" ry="5" transform="rotate(216 -3 4.3)" fill="#f7b6cc" stroke="#e58dab" strokeWidth="0.8" />
+                        <ellipse cx="-4.8" cy="-1.5" rx="3.8" ry="5" transform="rotate(288 -4.8 -1.5)" fill="#f5a9c4" stroke="#e58dab" strokeWidth="0.8" />
+                        <circle cx="0" cy="0" r="2.4" fill="#f4c45b" stroke="#d59b45" strokeWidth="0.7" />
+                    </g>
+                )}
+
+                {showMomiji && (
+                    <g transform="translate(88 16) rotate(12) scale(0.78)" aria-hidden="true">
+                        <path
+                            d="M0 14 C-1 10 -1 6 -1 3 C-5 6 -10 8 -14 7 C-12 4 -9 1 -6 -1 C-10 -1 -13 -3 -14 -5 C-11 -7 -7 -8 -4 -7 C-4 -11 -2 -14 0 -16 C2 -14 4 -11 4 -7 C7 -8 11 -7 14 -5 C13 -3 10 -1 6 -1 C9 1 12 4 14 7 C10 8 5 6 1 3 C1 6 1 10 0 14 Z"
+                            fill="#e6a14d"
+                            stroke="#b86f32"
+                            strokeWidth="1.2"
+                            strokeLinejoin="round"
+                        />
+                        <path d="M0 11 L0 -9 M0 1 L-6 -2 M0 1 L6 -2" fill="none" stroke="#f7d27d" strokeWidth="1.2" strokeLinecap="round" />
+                    </g>
+                )}
+
+                {showSnowflake && (
+                    <g transform="translate(88 16) rotate(12)" aria-hidden="true">
+                        <g stroke="#b9e8ff" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                            <path d="M0 -10 L0 10 M-8.7 -5 L8.7 5 M-8.7 5 L8.7 -5" />
+                            <path d="M0 -10 L-2.5 -7 M0 -10 L2.5 -7 M0 10 L-2.5 7 M0 10 L2.5 7" />
+                            <path d="M-8.7 -5 L-5.2 -4.8 M-8.7 -5 L-7 -1.8 M8.7 5 L5.2 4.8 M8.7 5 L7 1.8" />
+                            <path d="M-8.7 5 L-5.2 4.8 M-8.7 5 L-7 1.8 M8.7 -5 L5.2 -4.8 M8.7 -5 L7 -1.8" />
+                        </g>
+                        <circle cx="0" cy="0" r="1.8" fill="#e9f8ff" stroke="#8acde9" strokeWidth="0.7" />
+                    </g>
+                )}
 
                 {/* ほっぺ */}
                 <circle cx="20" cy="70" r="12" fill={cheekColor} />
@@ -140,11 +182,14 @@ type TenchanCompanionProps = {
     lang?: 'ja' | 'en';
     weather?: TenchanWeather;
     showUmbrella?: boolean;
+    showSakura?: boolean;
+    showMomiji?: boolean;
+    showSnowflake?: boolean;
     overrideDialog?: { text: string; mood: "happy" | "neutral" | "sad" | "scared" | "sleepy" | "looking" | "surprised" | "talking" } | null;
     onClick?: () => void;
 };
 
-export default function TenchanCompanion({ section, lang = 'ja', weather, showUmbrella = true, overrideDialog, onClick }: TenchanCompanionProps) {
+export default function TenchanCompanion({ section, lang = 'ja', weather, showUmbrella = true, showSakura = false, showMomiji = false, showSnowflake = false, overrideDialog, onClick }: TenchanCompanionProps) {
     // セクションに応じたデフォルトメッセージと表情を設定
     const getDialogue = () => {
         const byLang = {
@@ -227,7 +272,7 @@ export default function TenchanCompanion({ section, lang = 'ja', weather, showUm
                         <path d="M43 104 Q38 116 52 116" fill="none" stroke="#6b4a3a" strokeWidth="5" strokeLinecap="round" />
                     </svg>
                 )}
-                <CharacterFace mood={activeDialog.mood} />
+                <CharacterFace mood={activeDialog.mood} showSakura={showSakura} showMomiji={showMomiji} showSnowflake={showSnowflake} />
             </motion.div>
         </div>
     );

--- a/src/components/TenchanCompanion.tsx
+++ b/src/components/TenchanCompanion.tsx
@@ -12,6 +12,9 @@ type CharacterFaceProps = {
     showSakura?: boolean;
     showMomiji?: boolean;
     showSnowflake?: boolean;
+    showRainDrop?: boolean;
+    showLightning?: boolean;
+    showNightStar?: boolean;
 };
 
 export function CharacterFace({
@@ -22,6 +25,9 @@ export function CharacterFace({
     showSakura = false,
     showMomiji = false,
     showSnowflake = false,
+    showRainDrop = false,
+    showLightning = false,
+    showNightStar = false,
 }: CharacterFaceProps) {
 
     const getMouthPath = () => {
@@ -107,7 +113,7 @@ export function CharacterFace({
                 )}
 
                 {showSnowflake && (
-                    <g transform="translate(88 16) rotate(12)" aria-hidden="true">
+                    <g transform="translate(88 16) rotate(12)" aria-hidden="true" data-weather-accessory="snow">
                         <g stroke="#b9e8ff" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
                             <path d="M0 -10 L0 10 M-8.7 -5 L8.7 5 M-8.7 5 L8.7 -5" />
                             <path d="M0 -10 L-2.5 -7 M0 -10 L2.5 -7 M0 10 L-2.5 7 M0 10 L2.5 7" />
@@ -115,6 +121,43 @@ export function CharacterFace({
                             <path d="M-8.7 5 L-5.2 4.8 M-8.7 5 L-7 1.8 M8.7 -5 L5.2 -4.8 M8.7 -5 L7 -1.8" />
                         </g>
                         <circle cx="0" cy="0" r="1.8" fill="#e9f8ff" stroke="#8acde9" strokeWidth="0.7" />
+                    </g>
+                )}
+
+                {showRainDrop && (
+                    <g transform="translate(88 15) rotate(10)" aria-hidden="true" data-weather-accessory="rain">
+                        <path
+                            d="M0 -10 C-2.6 -6 -6.2 -2.3 -6.2 1.4 A6.2 6.2 0 0 0 6.2 1.4 C6.2 -2.3 2.6 -6 0 -10 Z"
+                            fill="#9edcf2"
+                            stroke="#4f9fc3"
+                            strokeWidth="1.3"
+                            strokeLinejoin="round"
+                        />
+                        <path d="M-2.4 -1.2 C-2.1 -3.1 -1.2 -4.5 0 -5.9" fill="none" stroke="#eaffff" strokeWidth="1.2" strokeLinecap="round" opacity="0.82" />
+                    </g>
+                )}
+
+                {showLightning && (
+                    <g transform="translate(88 15) rotate(8)" aria-hidden="true" data-weather-accessory="thunder">
+                        <path
+                            d="M2 -12 L-6 1 L0 0 L-3 12 L8 -3 L2 -2 Z"
+                            fill="#f6d45f"
+                            stroke="#bd8b32"
+                            strokeWidth="1.2"
+                            strokeLinejoin="round"
+                        />
+                    </g>
+                )}
+
+                {showNightStar && (
+                    <g transform="translate(88 15)" aria-hidden="true" data-weather-accessory="night">
+                        <path
+                            d="M0 -11 L2.2 -3.1 L10.5 -3.1 L3.8 1.6 L6.2 9.5 L0 4.9 L-6.2 9.5 L-3.8 1.6 L-10.5 -3.1 L-2.2 -3.1 Z"
+                            fill="#f8e7a1"
+                            stroke="#c8a95c"
+                            strokeWidth="1"
+                            strokeLinejoin="round"
+                        />
                     </g>
                 )}
 
@@ -185,11 +228,14 @@ type TenchanCompanionProps = {
     showSakura?: boolean;
     showMomiji?: boolean;
     showSnowflake?: boolean;
+    showRainDrop?: boolean;
+    showLightning?: boolean;
+    showNightStar?: boolean;
     overrideDialog?: { text: string; mood: "happy" | "neutral" | "sad" | "scared" | "sleepy" | "looking" | "surprised" | "talking" } | null;
     onClick?: () => void;
 };
 
-export default function TenchanCompanion({ section, lang = 'ja', weather, showUmbrella = true, showSakura = false, showMomiji = false, showSnowflake = false, overrideDialog, onClick }: TenchanCompanionProps) {
+export default function TenchanCompanion({ section, lang = 'ja', weather, showUmbrella = true, showSakura = false, showMomiji = false, showSnowflake = false, showRainDrop = false, showLightning = false, showNightStar = false, overrideDialog, onClick }: TenchanCompanionProps) {
     // セクションに応じたデフォルトメッセージと表情を設定
     const getDialogue = () => {
         const byLang = {
@@ -252,6 +298,7 @@ export default function TenchanCompanion({ section, lang = 'ja', weather, showUm
 
             {/* てんちゃん本体 */}
             <motion.div
+                data-testid="tenchan-companion"
                 className={`relative w-24 h-24 md:w-32 md:h-32 ${onClick ? 'pointer-events-auto cursor-pointer' : ''}`}
                 initial={{ y: 100, opacity: 0 }}
                 animate={{ y: 0, opacity: 1 }}
@@ -272,7 +319,15 @@ export default function TenchanCompanion({ section, lang = 'ja', weather, showUm
                         <path d="M43 104 Q38 116 52 116" fill="none" stroke="#6b4a3a" strokeWidth="5" strokeLinecap="round" />
                     </svg>
                 )}
-                <CharacterFace mood={activeDialog.mood} showSakura={showSakura} showMomiji={showMomiji} showSnowflake={showSnowflake} />
+                <CharacterFace
+                    mood={activeDialog.mood}
+                    showSakura={showSakura}
+                    showMomiji={showMomiji}
+                    showSnowflake={showSnowflake}
+                    showRainDrop={showRainDrop}
+                    showLightning={showLightning}
+                    showNightStar={showNightStar}
+                />
             </motion.div>
         </div>
     );

--- a/src/components/canvas/MoonriseTransitionCanvas.tsx
+++ b/src/components/canvas/MoonriseTransitionCanvas.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { motion } from 'framer-motion';
+import MoonPhase from '@/components/dom/MoonPhase';
 
 // Night transition aligned with sunny style: layered atmosphere + rising moonlight.
 export default function MoonriseTransitionCanvas() {
@@ -68,13 +69,14 @@ export default function MoonriseTransitionCanvas() {
                     top: '7%',
                     width: '122px',
                     height: '122px',
-                    background: 'radial-gradient(circle, #f8fbff 0%, #dfeeff 34%, #b9d1ff 60%, #8db2ec 82%, rgba(128,164,222,0) 100%)',
-                    boxShadow: '0 0 96px 32px rgba(156,194,252,0.34), 0 0 196px 112px rgba(90,130,198,0.22)',
+                    boxShadow: 'none',
                 }}
                 initial={{ y: 24, scale: 0.88, opacity: 0.08 }}
                 animate={{ y: [24, 6, 0], scale: [0.88, 1.0, 1.0], opacity: [0.08, 0.62, 0.7] }}
                 transition={{ duration: 1.35, ease: [0.22, 1, 0.36, 1] }}
-            />
+            >
+                <MoonPhase className="absolute inset-0" />
+            </motion.div>
 
             <motion.div
                 className="absolute rounded-full pointer-events-none border border-slate-100/40"

--- a/src/components/canvas/SunburstTransitionCanvas.tsx
+++ b/src/components/canvas/SunburstTransitionCanvas.tsx
@@ -12,7 +12,7 @@ export default function SunburstTransitionCanvas() {
     const isSpringSun = season === 'spring';
     const isAutumnSun = season === 'autumn';
     const isGeshiSun = season === 'summer' && seasonEvent === 'geshi';
-    const isTsuyuSun = seasonEvent === 'tsuyu' && (season === 'summer' || season === 'spring');
+    const isTsuyuSun = season === 'summer' && seasonEvent === 'tsuyu';
     const isCoolSun = isGeshiSun || isTsuyuSun;
     const background = isSpringSun
         ? 'linear-gradient(180deg, #f6e8ee 0%, #fdf3f7 42%, #fffafc 74%, #ffffff 100%)'

--- a/src/components/canvas/SunburstTransitionCanvas.tsx
+++ b/src/components/canvas/SunburstTransitionCanvas.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion';
 import { useStore } from '@/store';
+import { AUTUMN_BACKGROUND_GRADIENT } from '@/lib/otenkigurashiSeasonal';
 
 // 晴れの遷移: 下から昇る太陽と斜めの層状ゴッドレイ
 
@@ -14,7 +15,7 @@ export default function SunburstTransitionCanvas() {
     const background = isSpringSun
         ? 'linear-gradient(180deg, #f6e8ee 0%, #fdf3f7 42%, #fffafc 74%, #ffffff 100%)'
         : isAutumnSun
-            ? 'linear-gradient(180deg, #c7ded9 0%, #f1e6ce 50%, #e4b36f 100%)'
+            ? AUTUMN_BACKGROUND_GRADIENT
         : isGeshiSun
             ? 'linear-gradient(180deg, #a9d6e8 0%, #cfe8ee 42%, #e8f0e8 74%, #f7edcf 100%)'
         : 'linear-gradient(180deg, #82cbf6 0%, #dff2ff 42%, #fff3d8 74%, #ffefcf 100%)';
@@ -42,12 +43,12 @@ export default function SunburstTransitionCanvas() {
                 className="absolute right-[8%] top-[9%] w-24 h-24 md:w-32 md:h-32 rounded-full pointer-events-none"
                 style={{
                     background: isSpringSun
-                        ? 'radial-gradient(circle at 35% 35%, rgba(255,244,214,0.98) 0%, rgba(241,157,188,0.96) 38%, rgba(205,100,139,0.94) 100%)'
+                        ? 'radial-gradient(circle at 35% 35%, rgba(255,248,214,0.98) 0%, rgba(255,218,133,0.92) 38%, rgba(242,176,76,0.88) 100%)'
                     : isGeshiSun
                         ? 'radial-gradient(circle at 35% 35%, rgba(255,248,211,0.96) 0%, rgba(255,220,133,0.90) 38%, rgba(246,181,70,0.84) 100%)'
                         : 'radial-gradient(circle at 35% 35%, rgba(255,245,180,0.96) 0%, rgba(255,213,112,0.92) 38%, rgba(255,170,58,0.92) 100%)',
                     boxShadow: isSpringSun
-                        ? '0 0 45px rgba(224,122,159,0.32), 0 0 110px rgba(205,100,139,0.16)'
+                        ? '0 0 45px rgba(247,190,101,0.28), 0 0 110px rgba(236,163,80,0.12)'
                         : isGeshiSun
                             ? '0 0 24px rgba(151,211,238,0.18), 0 0 66px rgba(120,190,224,0.07)'
                         : '0 0 45px rgba(255,205,110,0.55), 0 0 110px rgba(255,187,82,0.35)',
@@ -61,8 +62,8 @@ export default function SunburstTransitionCanvas() {
                 className="absolute right-[3%] top-[2%] w-44 h-44 md:w-64 md:h-64 rounded-full pointer-events-none"
                 style={{
                     background: isSpringSun
-                        ? 'radial-gradient(circle, rgba(255,205,219,0.22) 0%, rgba(229,128,166,0.07) 42%, rgba(229,128,166,0.0) 74%)'
-                    : isGeshiSun
+                        ? 'radial-gradient(circle, rgba(255,224,157,0.20) 0%, rgba(245,183,97,0.06) 42%, rgba(245,183,97,0.0) 74%)'
+                        : isGeshiSun
                         ? 'radial-gradient(circle, rgba(188,228,245,0.10) 0%, rgba(151,208,234,0.025) 42%, rgba(151,208,234,0.0) 74%)'
                         : 'radial-gradient(circle, rgba(255,220,150,0.36) 0%, rgba(255,220,150,0.08) 42%, rgba(255,220,150,0.0) 74%)',
                 }}

--- a/src/components/canvas/SunburstTransitionCanvas.tsx
+++ b/src/components/canvas/SunburstTransitionCanvas.tsx
@@ -2,7 +2,7 @@
 
 import { motion } from 'framer-motion';
 import { useStore } from '@/store';
-import { AUTUMN_BACKGROUND_GRADIENT } from '@/lib/otenkigurashiSeasonal';
+import { AUTUMN_BACKGROUND_GRADIENT, TSUYU_CLEAR_BACKGROUND_GRADIENT } from '@/lib/otenkigurashiSeasonal';
 
 // 晴れの遷移: 下から昇る太陽と斜めの層状ゴッドレイ
 
@@ -12,10 +12,14 @@ export default function SunburstTransitionCanvas() {
     const isSpringSun = season === 'spring';
     const isAutumnSun = season === 'autumn';
     const isGeshiSun = season === 'summer' && seasonEvent === 'geshi';
+    const isTsuyuSun = seasonEvent === 'tsuyu' && (season === 'summer' || season === 'spring');
+    const isCoolSun = isGeshiSun || isTsuyuSun;
     const background = isSpringSun
         ? 'linear-gradient(180deg, #f6e8ee 0%, #fdf3f7 42%, #fffafc 74%, #ffffff 100%)'
         : isAutumnSun
             ? AUTUMN_BACKGROUND_GRADIENT
+        : isTsuyuSun
+            ? TSUYU_CLEAR_BACKGROUND_GRADIENT
         : isGeshiSun
             ? 'linear-gradient(180deg, #a9d6e8 0%, #cfe8ee 42%, #e8f0e8 74%, #f7edcf 100%)'
         : 'linear-gradient(180deg, #82cbf6 0%, #dff2ff 42%, #fff3d8 74%, #ffefcf 100%)';
@@ -29,8 +33,10 @@ export default function SunburstTransitionCanvas() {
             <motion.div
                 className="absolute inset-0 pointer-events-none"
                 style={{
-                    background: isGeshiSun
-                        ? 'radial-gradient(ellipse 100% 72% at 76% 18%, rgba(190,229,246,0.14) 0%, rgba(164,215,237,0.06) 44%, rgba(164,215,237,0) 78%)'
+                    background: isCoolSun
+                        ? isTsuyuSun
+                            ? 'radial-gradient(ellipse 100% 72% at 76% 18%, rgba(191,222,239,0.16) 0%, rgba(164,195,220,0.06) 44%, rgba(164,195,220,0) 78%)'
+                            : 'radial-gradient(ellipse 100% 72% at 76% 18%, rgba(190,229,246,0.14) 0%, rgba(164,215,237,0.06) 44%, rgba(164,215,237,0) 78%)'
                         : 'radial-gradient(ellipse 100% 72% at 76% 18%, rgba(255,234,190,0.28) 0%, rgba(255,226,176,0.12) 44%, rgba(255,226,176,0) 78%)',
                 }}
                 initial={{ opacity: 0 }}
@@ -44,17 +50,17 @@ export default function SunburstTransitionCanvas() {
                 style={{
                     background: isSpringSun
                         ? 'radial-gradient(circle at 35% 35%, rgba(255,248,214,0.98) 0%, rgba(255,218,133,0.92) 38%, rgba(242,176,76,0.88) 100%)'
-                    : isGeshiSun
+                    : isCoolSun
                         ? 'radial-gradient(circle at 35% 35%, rgba(255,248,211,0.96) 0%, rgba(255,220,133,0.90) 38%, rgba(246,181,70,0.84) 100%)'
                         : 'radial-gradient(circle at 35% 35%, rgba(255,245,180,0.96) 0%, rgba(255,213,112,0.92) 38%, rgba(255,170,58,0.92) 100%)',
                     boxShadow: isSpringSun
                         ? '0 0 45px rgba(247,190,101,0.28), 0 0 110px rgba(236,163,80,0.12)'
-                        : isGeshiSun
+                        : isCoolSun
                             ? '0 0 24px rgba(151,211,238,0.18), 0 0 66px rgba(120,190,224,0.07)'
                         : '0 0 45px rgba(255,205,110,0.55), 0 0 110px rgba(255,187,82,0.35)',
                 }}
                 initial={{ opacity: 0, scale: 0.86 }}
-                animate={{ opacity: isGeshiSun ? [0, 0.78, 0.86] : [0, 0.94, 1], scale: [0.86, 1.04, 1.0] }}
+                animate={{ opacity: isCoolSun ? [0, 0.78, 0.86] : [0, 0.94, 1], scale: [0.86, 1.04, 1.0] }}
                 transition={{ duration: 0.9, ease: [0.22, 1, 0.36, 1] }}
             />
 
@@ -63,7 +69,7 @@ export default function SunburstTransitionCanvas() {
                 style={{
                     background: isSpringSun
                         ? 'radial-gradient(circle, rgba(255,224,157,0.20) 0%, rgba(245,183,97,0.06) 42%, rgba(245,183,97,0.0) 74%)'
-                        : isGeshiSun
+                        : isCoolSun
                         ? 'radial-gradient(circle, rgba(188,228,245,0.10) 0%, rgba(151,208,234,0.025) 42%, rgba(151,208,234,0.0) 74%)'
                         : 'radial-gradient(circle, rgba(255,220,150,0.36) 0%, rgba(255,220,150,0.08) 42%, rgba(255,220,150,0.0) 74%)',
                 }}
@@ -81,7 +87,7 @@ export default function SunburstTransitionCanvas() {
                     width: '190%',
                     height: '190%',
                     transform: 'rotate(-24deg)',
-                    background: isGeshiSun
+                    background: isCoolSun
                         ? 'linear-gradient(104deg, rgba(221,244,253,0.26) 0%, rgba(190,226,242,0.14) 24%, rgba(161,211,235,0.06) 46%, rgba(161,211,235,0.0) 74%)'
                         : 'linear-gradient(104deg, rgba(255,247,220,0.7) 0%, rgba(255,236,194,0.36) 24%, rgba(255,220,162,0.15) 46%, rgba(255,210,156,0.0) 74%)',
                     filter: 'blur(1.5px)',
@@ -100,7 +106,7 @@ export default function SunburstTransitionCanvas() {
                     width: '180%',
                     height: '180%',
                     transform: 'rotate(-24deg)',
-                    background: isGeshiSun
+                    background: isCoolSun
                         ? 'linear-gradient(105deg, rgba(229,248,255,0.20) 0%, rgba(195,229,242,0.10) 22%, rgba(168,213,234,0.035) 44%, rgba(168,213,234,0.0) 68%)'
                         : 'linear-gradient(105deg, rgba(255,251,236,0.52) 0%, rgba(255,241,210,0.24) 22%, rgba(255,224,170,0.08) 44%, rgba(255,214,165,0.0) 68%)',
                     filter: 'blur(7px)',
@@ -119,7 +125,7 @@ export default function SunburstTransitionCanvas() {
                     width: '160%',
                     height: '170%',
                     transform: 'rotate(-24deg)',
-                    background: isGeshiSun
+                    background: isCoolSun
                         ? 'linear-gradient(102deg, rgba(235,250,255,0.17) 0%, rgba(205,234,245,0.08) 20%, rgba(174,217,236,0.025) 40%, rgba(174,217,236,0.0) 62%)'
                         : 'linear-gradient(102deg, rgba(255,255,246,0.48) 0%, rgba(255,247,224,0.22) 20%, rgba(255,232,186,0.06) 40%, rgba(255,220,180,0.0) 62%)',
                     filter: 'blur(14px)',
@@ -133,7 +139,7 @@ export default function SunburstTransitionCanvas() {
             {/* 露出の余韻 */}
             <motion.div
                 className="absolute inset-0 pointer-events-none"
-                style={{ background: isGeshiSun
+                style={{ background: isCoolSun
                     ? 'linear-gradient(180deg, rgba(220,245,253,0.0) 0%, rgba(199,231,243,0.035) 54%, rgba(179,218,235,0.08) 100%)'
                     : 'linear-gradient(180deg, rgba(255,246,220,0.0) 0%, rgba(255,239,206,0.07) 54%, rgba(255,233,196,0.16) 100%)' }}
                 initial={{ opacity: 0 }}

--- a/src/components/canvas/SunburstTransitionCanvas.tsx
+++ b/src/components/canvas/SunburstTransitionCanvas.tsx
@@ -7,9 +7,16 @@ import { useStore } from '@/store';
 
 export default function SunburstTransitionCanvas() {
     const season = useStore((state) => state.season);
+    const seasonEvent = useStore((state) => state.seasonEvent);
     const isSpringSun = season === 'spring';
+    const isAutumnSun = season === 'autumn';
+    const isGeshiSun = season === 'summer' && seasonEvent === 'geshi';
     const background = isSpringSun
         ? 'linear-gradient(180deg, #f6e8ee 0%, #fdf3f7 42%, #fffafc 74%, #ffffff 100%)'
+        : isAutumnSun
+            ? 'linear-gradient(180deg, #c7ded9 0%, #f1e6ce 50%, #e4b36f 100%)'
+        : isGeshiSun
+            ? 'linear-gradient(180deg, #a9d6e8 0%, #cfe8ee 42%, #e8f0e8 74%, #f7edcf 100%)'
         : 'linear-gradient(180deg, #82cbf6 0%, #dff2ff 42%, #fff3d8 74%, #ffefcf 100%)';
 
     return (
@@ -21,7 +28,9 @@ export default function SunburstTransitionCanvas() {
             <motion.div
                 className="absolute inset-0 pointer-events-none"
                 style={{
-                    background: 'radial-gradient(ellipse 100% 72% at 76% 18%, rgba(255,234,190,0.28) 0%, rgba(255,226,176,0.12) 44%, rgba(255,226,176,0) 78%)',
+                    background: isGeshiSun
+                        ? 'radial-gradient(ellipse 100% 72% at 76% 18%, rgba(190,229,246,0.14) 0%, rgba(164,215,237,0.06) 44%, rgba(164,215,237,0) 78%)'
+                        : 'radial-gradient(ellipse 100% 72% at 76% 18%, rgba(255,234,190,0.28) 0%, rgba(255,226,176,0.12) 44%, rgba(255,226,176,0) 78%)',
                 }}
                 initial={{ opacity: 0 }}
                 animate={{ opacity: [0.08, 0.24, 0.18] }}
@@ -34,13 +43,17 @@ export default function SunburstTransitionCanvas() {
                 style={{
                     background: isSpringSun
                         ? 'radial-gradient(circle at 35% 35%, rgba(255,244,214,0.98) 0%, rgba(241,157,188,0.96) 38%, rgba(205,100,139,0.94) 100%)'
+                    : isGeshiSun
+                        ? 'radial-gradient(circle at 35% 35%, rgba(255,248,211,0.96) 0%, rgba(255,220,133,0.90) 38%, rgba(246,181,70,0.84) 100%)'
                         : 'radial-gradient(circle at 35% 35%, rgba(255,245,180,0.96) 0%, rgba(255,213,112,0.92) 38%, rgba(255,170,58,0.92) 100%)',
                     boxShadow: isSpringSun
                         ? '0 0 45px rgba(224,122,159,0.32), 0 0 110px rgba(205,100,139,0.16)'
+                        : isGeshiSun
+                            ? '0 0 24px rgba(151,211,238,0.18), 0 0 66px rgba(120,190,224,0.07)'
                         : '0 0 45px rgba(255,205,110,0.55), 0 0 110px rgba(255,187,82,0.35)',
                 }}
                 initial={{ opacity: 0, scale: 0.86 }}
-                animate={{ opacity: [0, 0.94, 1], scale: [0.86, 1.04, 1.0] }}
+                animate={{ opacity: isGeshiSun ? [0, 0.78, 0.86] : [0, 0.94, 1], scale: [0.86, 1.04, 1.0] }}
                 transition={{ duration: 0.9, ease: [0.22, 1, 0.36, 1] }}
             />
 
@@ -49,6 +62,8 @@ export default function SunburstTransitionCanvas() {
                 style={{
                     background: isSpringSun
                         ? 'radial-gradient(circle, rgba(255,205,219,0.22) 0%, rgba(229,128,166,0.07) 42%, rgba(229,128,166,0.0) 74%)'
+                    : isGeshiSun
+                        ? 'radial-gradient(circle, rgba(188,228,245,0.10) 0%, rgba(151,208,234,0.025) 42%, rgba(151,208,234,0.0) 74%)'
                         : 'radial-gradient(circle, rgba(255,220,150,0.36) 0%, rgba(255,220,150,0.08) 42%, rgba(255,220,150,0.0) 74%)',
                 }}
                 initial={{ opacity: 0, rotate: -10, scale: 0.86 }}
@@ -65,7 +80,9 @@ export default function SunburstTransitionCanvas() {
                     width: '190%',
                     height: '190%',
                     transform: 'rotate(-24deg)',
-                    background: 'linear-gradient(104deg, rgba(255,247,220,0.7) 0%, rgba(255,236,194,0.36) 24%, rgba(255,220,162,0.15) 46%, rgba(255,210,156,0.0) 74%)',
+                    background: isGeshiSun
+                        ? 'linear-gradient(104deg, rgba(221,244,253,0.26) 0%, rgba(190,226,242,0.14) 24%, rgba(161,211,235,0.06) 46%, rgba(161,211,235,0.0) 74%)'
+                        : 'linear-gradient(104deg, rgba(255,247,220,0.7) 0%, rgba(255,236,194,0.36) 24%, rgba(255,220,162,0.15) 46%, rgba(255,210,156,0.0) 74%)',
                     filter: 'blur(1.5px)',
                     mixBlendMode: 'screen',
                 }}
@@ -82,7 +99,9 @@ export default function SunburstTransitionCanvas() {
                     width: '180%',
                     height: '180%',
                     transform: 'rotate(-24deg)',
-                    background: 'linear-gradient(105deg, rgba(255,251,236,0.52) 0%, rgba(255,241,210,0.24) 22%, rgba(255,224,170,0.08) 44%, rgba(255,214,165,0.0) 68%)',
+                    background: isGeshiSun
+                        ? 'linear-gradient(105deg, rgba(229,248,255,0.20) 0%, rgba(195,229,242,0.10) 22%, rgba(168,213,234,0.035) 44%, rgba(168,213,234,0.0) 68%)'
+                        : 'linear-gradient(105deg, rgba(255,251,236,0.52) 0%, rgba(255,241,210,0.24) 22%, rgba(255,224,170,0.08) 44%, rgba(255,214,165,0.0) 68%)',
                     filter: 'blur(7px)',
                     mixBlendMode: 'screen',
                 }}
@@ -99,7 +118,9 @@ export default function SunburstTransitionCanvas() {
                     width: '160%',
                     height: '170%',
                     transform: 'rotate(-24deg)',
-                    background: 'linear-gradient(102deg, rgba(255,255,246,0.48) 0%, rgba(255,247,224,0.22) 20%, rgba(255,232,186,0.06) 40%, rgba(255,220,180,0.0) 62%)',
+                    background: isGeshiSun
+                        ? 'linear-gradient(102deg, rgba(235,250,255,0.17) 0%, rgba(205,234,245,0.08) 20%, rgba(174,217,236,0.025) 40%, rgba(174,217,236,0.0) 62%)'
+                        : 'linear-gradient(102deg, rgba(255,255,246,0.48) 0%, rgba(255,247,224,0.22) 20%, rgba(255,232,186,0.06) 40%, rgba(255,220,180,0.0) 62%)',
                     filter: 'blur(14px)',
                     mixBlendMode: 'screen',
                 }}
@@ -111,7 +132,9 @@ export default function SunburstTransitionCanvas() {
             {/* 露出の余韻 */}
             <motion.div
                 className="absolute inset-0 pointer-events-none"
-                style={{ background: 'linear-gradient(180deg, rgba(255,246,220,0.0) 0%, rgba(255,239,206,0.07) 54%, rgba(255,233,196,0.16) 100%)' }}
+                style={{ background: isGeshiSun
+                    ? 'linear-gradient(180deg, rgba(220,245,253,0.0) 0%, rgba(199,231,243,0.035) 54%, rgba(179,218,235,0.08) 100%)'
+                    : 'linear-gradient(180deg, rgba(255,246,220,0.0) 0%, rgba(255,239,206,0.07) 54%, rgba(255,233,196,0.16) 100%)' }}
                 initial={{ opacity: 0 }}
                 animate={{ opacity: [0.0, 0.2, 0.16] }}
                 transition={{ duration: 0.9, ease: [0.22, 1, 0.36, 1] }}

--- a/src/components/dom/MoonPhase.tsx
+++ b/src/components/dom/MoonPhase.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useId, useState, type CSSProperties } from 'react';
-import { getMoonPhase, getMoonPhaseMask } from '@/lib/moonPhase';
+import { getDisplayMoonPhase, getMoonPhase, getMoonPhaseMask } from '@/lib/moonPhase';
 
 type MoonPhaseProps = {
     phaseOverride?: number | null;
@@ -27,7 +27,7 @@ export default function MoonPhase({ phaseOverride, className = '', style }: Moon
         return () => window.clearInterval(timer);
     }, [phaseOverride]);
 
-    const phase = phaseOverride ?? livePhase;
+    const phase = getDisplayMoonPhase(phaseOverride ?? livePhase);
     const moonMask = getMoonPhaseMask(phase);
     const fadeWidth = 8;
     const fadeStart = Math.max(0, moonMask.boundaryPercent - fadeWidth);

--- a/src/components/dom/MoonPhase.tsx
+++ b/src/components/dom/MoonPhase.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useEffect, useId, useState, type CSSProperties } from 'react';
+import { getMoonPhase, getMoonPhaseMask } from '@/lib/moonPhase';
+
+type MoonPhaseProps = {
+    phaseOverride?: number | null;
+    className?: string;
+    style?: CSSProperties;
+};
+
+export default function MoonPhase({ phaseOverride, className = '', style }: MoonPhaseProps) {
+    const [livePhase, setLivePhase] = useState(() => getMoonPhase());
+    const idSuffix = useId().replace(/:/g, '');
+    const gradientId = `moon-gradient-${idSuffix}`;
+    const maskId = `moon-mask-${idSuffix}`;
+    const maskGradientId = `moon-mask-gradient-${idSuffix}`;
+    const circleClipId = `moon-circle-${idSuffix}`;
+
+    useEffect(() => {
+        if (phaseOverride !== undefined && phaseOverride !== null) {
+            return;
+        }
+
+        const updatePhase = () => setLivePhase(getMoonPhase());
+        const timer = window.setInterval(updatePhase, 60 * 60 * 1000);
+        return () => window.clearInterval(timer);
+    }, [phaseOverride]);
+
+    const phase = phaseOverride ?? livePhase;
+    const moonMask = getMoonPhaseMask(phase);
+    const fadeWidth = 8;
+    const fadeStart = Math.max(0, moonMask.boundaryPercent - fadeWidth);
+    const fadeEnd = Math.min(100, moonMask.boundaryPercent + fadeWidth);
+    const moonVisible = !moonMask.isNew;
+
+    return (
+        <div
+            className={`pointer-events-none ${className}`}
+            style={style}
+            aria-hidden="true"
+        >
+            <svg viewBox="0 0 100 100" className="absolute inset-0 h-full w-full overflow-visible" aria-hidden="true">
+                <defs>
+                    <radialGradient id={gradientId} cx="35%" cy="35%" r="70%">
+                        <stop offset="0%" stopColor="#f3f7ff" />
+                        <stop offset="54%" stopColor="#d6e1f4" />
+                        <stop offset="100%" stopColor="#b4c5df" />
+                    </radialGradient>
+                    <linearGradient id={maskGradientId} x1="0" y1="0" x2="100" y2="0" gradientUnits="userSpaceOnUse">
+                        {moonMask.isFull ? (
+                            <stop offset="0%" stopColor="white" />
+                        ) : moonMask.illuminatedSide === 'right' ? (
+                            <>
+                                <stop offset={`${fadeStart}%`} stopColor="black" />
+                                <stop offset={`${fadeEnd}%`} stopColor="white" />
+                            </>
+                        ) : (
+                            <>
+                                <stop offset={`${fadeStart}%`} stopColor="white" />
+                                <stop offset={`${fadeEnd}%`} stopColor="black" />
+                            </>
+                        )}
+                    </linearGradient>
+                    <mask id={maskId} maskUnits="userSpaceOnUse" x="0" y="0" width="100" height="100">
+                        <rect width="100" height="100" fill={`url(#${maskGradientId})`} />
+                    </mask>
+                    <clipPath id={circleClipId}>
+                        <circle cx="50" cy="50" r="50" />
+                    </clipPath>
+                </defs>
+                {moonVisible && (
+                    <>
+                        <circle
+                            cx="50"
+                            cy="50"
+                            r="50"
+                            fill={`url(#${gradientId})`}
+                            mask={`url(#${maskId})`}
+                        />
+                        <g mask={`url(#${maskId})`} clipPath={`url(#${circleClipId})`} opacity="0.14">
+                            <circle cx="29" cy="33" r="7" fill="#8798b6" />
+                            <circle cx="62" cy="57" r="5" fill="#90a1bd" />
+                            <circle cx="46" cy="73" r="3.5" fill="#8193b1" />
+                            <circle cx="72" cy="27" r="2.5" fill="#8b9bb8" />
+                        </g>
+                    </>
+                )}
+            </svg>
+        </div>
+    );
+}

--- a/src/components/dom/TopLeftMenu.tsx
+++ b/src/components/dom/TopLeftMenu.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useRouter } from 'next/navigation';
 import { useStore, type SeasonEventType, type SeasonType, type WeatherType } from '@/store';
+import { buildWorldStateQuery } from '@/lib/worldState';
 
 const MENU_COMMANDS = {
     ja: [
@@ -59,7 +60,7 @@ export default function TopLeftMenu() {
         if (href === '/otenkigurashi') {
             setActiveWork('02');
             const { weather: currentWeather, season: currentSeason, seasonEvent: currentSeasonEvent } = useStore.getState();
-            const otenkiHref = `/otenkigurashi?lang=${lang}&weather=${encodeURIComponent(currentWeather)}&season=${encodeURIComponent(currentSeason)}&seasonEvent=${encodeURIComponent(currentSeasonEvent)}`;
+            const otenkiHref = `/otenkigurashi?${buildWorldStateQuery({ weather: currentWeather, season: currentSeason, seasonEvent: currentSeasonEvent }, lang)}`;
 
             if (currentWeather === 'Rain') {
                 setTransitionType('rain');
@@ -105,9 +106,8 @@ export default function TopLeftMenu() {
             setActiveWork('05');
             setTransitionType('wave');
             const { weather: currentWeather } = useStore.getState();
-            const denshouoHref = currentWeather === 'Rain'
-                ? `/denshouo?lang=${lang}&weather=Rain`
-                : withLang('/denshouo');
+            const { season: currentSeason, seasonEvent: currentSeasonEvent } = useStore.getState();
+            const denshouoHref = `/denshouo?${buildWorldStateQuery({ weather: currentWeather, season: currentSeason, seasonEvent: currentSeasonEvent }, lang)}`;
             setTimeout(() => {
                 router.push(denshouoHref);
                 setTimeout(() => setTransitionType('none'), 900);
@@ -176,7 +176,7 @@ export default function TopLeftMenu() {
         appendHistory({ tone: 'info', text: `$ ${command}` });
 
         if (command.toLowerCase() === 'help') {
-            appendHistory({ tone: 'info', text: 'Available: sudo make rain|snow|clouds|clear|thunder|night|spring|summer|autumn|winter|sakura|hanagumori|geshi|momiji|tsukimi|yukigeshiki|season-clear, help, exit' });
+            appendHistory({ tone: 'info', text: 'Available: sudo make rain|snow|clouds|clear|thunder|night|spring|summer|autumn|winter|sakura|hanagumori|geshi|tsuyu|momiji|tsukimi|yukigeshiki|season-clear, help, exit' });
             return;
         }
 
@@ -194,6 +194,7 @@ export default function TopLeftMenu() {
                 hanagumori: { season: 'spring', weather: 'Clouds' },
                 geshi: { season: 'summer', weather: 'Clear', seasonEvent: 'geshi' },
                 gesi: { season: 'summer', weather: 'Clear', seasonEvent: 'geshi' },
+                tsuyu: { season: 'summer', weather: 'Clouds', seasonEvent: 'tsuyu' },
                 momiji: { season: 'autumn', weather: 'Clear' },
                 momizi: { season: 'autumn', weather: 'Clear' },
                 tsukimi: { season: 'autumn', weather: 'Night' },

--- a/src/components/dom/TopLeftMenu.tsx
+++ b/src/components/dom/TopLeftMenu.tsx
@@ -104,8 +104,12 @@ export default function TopLeftMenu() {
         if (href === '/denshouo') {
             setActiveWork('05');
             setTransitionType('wave');
+            const { weather: currentWeather } = useStore.getState();
+            const denshouoHref = currentWeather === 'Rain'
+                ? `/denshouo?lang=${lang}&weather=Rain`
+                : withLang('/denshouo');
             setTimeout(() => {
-                router.push(withLang('/denshouo'));
+                router.push(denshouoHref);
                 setTimeout(() => setTransitionType('none'), 900);
             }, 1800);
             return;

--- a/src/components/dom/WorksList.tsx
+++ b/src/components/dom/WorksList.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useStore } from '@/store';
+import { buildWorldStateQuery } from '@/lib/worldState';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
 
@@ -34,7 +35,7 @@ export default function WorksList({ works }: { works: Work[] }) {
         } else if (id === '02') {
             setActiveWork('02');
             const { weather: currentWeather, season: currentSeason, seasonEvent: currentSeasonEvent } = useStore.getState();
-            const otenkiHref = `/otenkigurashi?lang=${lang}&weather=${encodeURIComponent(currentWeather)}&season=${encodeURIComponent(currentSeason)}&seasonEvent=${encodeURIComponent(currentSeasonEvent)}`;
+            const otenkiHref = `/otenkigurashi?${buildWorldStateQuery({ weather: currentWeather, season: currentSeason, seasonEvent: currentSeasonEvent }, lang)}`;
 
             // 天候に応じて遷移アニメーションを分岐
             if (currentWeather === 'Rain') {
@@ -73,9 +74,8 @@ export default function WorksList({ works }: { works: Work[] }) {
             setActiveWork('05');
             setTransitionType('wave');
             const { weather: currentWeather } = useStore.getState();
-            const denshouoHref = currentWeather === 'Rain'
-                ? `/denshouo?lang=${lang}&weather=Rain`
-                : withLang('/denshouo');
+            const { season: currentSeason, seasonEvent: currentSeasonEvent } = useStore.getState();
+            const denshouoHref = `/denshouo?${buildWorldStateQuery({ weather: currentWeather, season: currentSeason, seasonEvent: currentSeasonEvent }, lang)}`;
             setTimeout(() => {
                 router.push(denshouoHref);
                 setTimeout(() => setTransitionType('none'), 900);

--- a/src/components/dom/WorksList.tsx
+++ b/src/components/dom/WorksList.tsx
@@ -72,8 +72,12 @@ export default function WorksList({ works }: { works: Work[] }) {
         } else if (id === '05') {
             setActiveWork('05');
             setTransitionType('wave');
+            const { weather: currentWeather } = useStore.getState();
+            const denshouoHref = currentWeather === 'Rain'
+                ? `/denshouo?lang=${lang}&weather=Rain`
+                : withLang('/denshouo');
             setTimeout(() => {
-                router.push(withLang('/denshouo'));
+                router.push(denshouoHref);
                 setTimeout(() => setTransitionType('none'), 900);
             }, 1800);
         } else {

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { resolveSeasonState } from '@/lib/seasonResolver';
+
 type WeatherType = 'Clear' | 'Rain' | 'Clouds' | 'Snow' | 'Night' | 'Morning' | 'Thunder';
 
 // Open-Meteo WMO weather code → WeatherType
@@ -17,7 +19,8 @@ function mapWeatherCode(code: number): WeatherType {
 
 export async function fetchPlanetData() {
     // サーバーのタイムゾーンに依存せず、常に日本時間(JST)で時刻を取得
-    const jstDate = new Date(new Date().toLocaleString('en-US', { timeZone: 'Asia/Tokyo' }));
+    const now = new Date();
+    const jstDate = new Date(now.toLocaleString('en-US', { timeZone: 'Asia/Tokyo' }));
     const hours = jstDate.getHours();
 
     let weather: WeatherType;
@@ -44,8 +47,12 @@ export async function fetchPlanetData() {
         }
     }
 
+    const { season, seasonEvent } = resolveSeasonState(now);
+
     return {
         weather,
+        season,
+        seasonEvent,
         contributions: 1240, // 年間コミット数
         activityLevel: 0.8,  // シェーダーに渡す「強さ」
     };

--- a/src/lib/moonPhase.ts
+++ b/src/lib/moonPhase.ts
@@ -1,0 +1,47 @@
+const SYNODIC_MONTH_DAYS = 29.530588853;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const KNOWN_NEW_MOON_UTC = Date.UTC(2000, 0, 6, 18, 14);
+
+const normalizePhase = (phase: number) => ((phase % 1) + 1) % 1;
+
+/** Returns the lunar phase in the range [0, 1): new moon = 0, full moon = 0.5. */
+export const getMoonPhase = (date = new Date()) => {
+    const elapsedDays = (date.getTime() - KNOWN_NEW_MOON_UTC) / DAY_MS;
+    return normalizePhase(elapsedDays / SYNODIC_MONTH_DAYS);
+};
+
+/** Builds the illuminated portion of a moon as an SVG path. */
+export const getMoonPhasePath = (phase: number, radius = 50) => {
+    const normalized = normalizePhase(phase);
+    if (normalized < 0.0001 || normalized > 0.9999) return '';
+    if (Math.abs(normalized - 0.5) < 0.0001) {
+        return `M 0 ${-radius} A ${radius} ${radius} 0 1 1 0 ${radius} A ${radius} ${radius} 0 1 1 0 ${-radius} Z`;
+    }
+
+    const terminatorRadius = Math.max(radius * 0.16, Math.abs(Math.cos(normalized * Math.PI * 2)) * radius);
+    if (normalized < 0.5) {
+        const terminatorSweep = normalized < 0.25 ? 0 : 1;
+        return `M 0 ${-radius} A ${radius} ${radius} 0 0 1 0 ${radius} A ${terminatorRadius} ${radius} 0 0 ${terminatorSweep} 0 ${-radius} Z`;
+    }
+
+    const terminatorSweep = normalized < 0.75 ? 0 : 1;
+    return `M 0 ${-radius} A ${radius} ${radius} 0 0 0 0 ${radius} A ${terminatorRadius} ${radius} 0 0 ${terminatorSweep} 0 ${-radius} Z`;
+};
+
+/** Returns the soft terminator position and illuminated side for the SVG mask. */
+export const getMoonPhaseMask = (phase: number) => {
+    const normalized = normalizePhase(phase);
+    return {
+        boundaryPercent: normalized <= 0.5 ? 100 - normalized * 200 : (1 - normalized) * 200,
+        illuminatedSide: normalized <= 0.5 ? 'right' as const : 'left' as const,
+        isNew: normalized < 0.0001 || normalized > 0.9999,
+        isFull: Math.abs(normalized - 0.5) < 0.0001,
+    };
+};
+
+/** Parses the optional preview query value without affecting normal URLs. */
+export const parseMoonPhaseOverride = (value: string | null) => {
+    if (value === null || value.trim() === '') return null;
+    const phase = Number(value);
+    return Number.isFinite(phase) ? normalizePhase(phase) : null;
+};

--- a/src/lib/moonPhase.ts
+++ b/src/lib/moonPhase.ts
@@ -1,8 +1,16 @@
 const SYNODIC_MONTH_DAYS = 29.530588853;
 const DAY_MS = 24 * 60 * 60 * 1000;
 const KNOWN_NEW_MOON_UTC = Date.UTC(2000, 0, 6, 18, 14);
+const DECORATIVE_FULL_MOON_THRESHOLD = 0.08;
 
 const normalizePhase = (phase: number) => ((phase % 1) + 1) % 1;
+
+/** Avoids a visually broken sliver by using a simple round moon near new moon. */
+export const getDisplayMoonPhase = (phase: number) => {
+    const normalized = normalizePhase(phase);
+    const distanceFromNew = Math.min(normalized, 1 - normalized);
+    return distanceFromNew <= DECORATIVE_FULL_MOON_THRESHOLD ? 0.5 : normalized;
+};
 
 /** Returns the lunar phase in the range [0, 1): new moon = 0, full moon = 0.5. */
 export const getMoonPhase = (date = new Date()) => {

--- a/src/lib/otenkigurashiSeasonal.ts
+++ b/src/lib/otenkigurashiSeasonal.ts
@@ -6,6 +6,21 @@ export const AUTUMN_BACKGROUND_GRADIENT =
 export const WINTER_BACKGROUND_GRADIENT =
     'linear-gradient(180deg, #aebdcb 0%, #d8e4ec 48%, #ffffff 100%)';
 
+export const SPRING_FLOWER_CLOUDY_BACKGROUND_GRADIENT =
+    'linear-gradient(180deg, #c5d1d9 0%, #e6e9e7 52%, #f3e8ed 100%)';
+
+export const TSUYU_CLEAR_BACKGROUND_GRADIENT =
+    'linear-gradient(180deg, #a9c4d9 0%, #c8d4dc 48%, #e8e1e4 100%)';
+
+export const TSUYU_CLOUDS_BACKGROUND_GRADIENT =
+    'linear-gradient(180deg, #7f93ae 0%, #aab7c7 52%, #c9c8d0 100%)';
+
+export const TSUYU_RAIN_BACKGROUND_GRADIENT =
+    'linear-gradient(180deg, #5790c8 0%, #8fb4d9 50%, #c8d5df 100%)';
+
+export const TSUYU_ATMOSPHERE_GRADIENT =
+    'linear-gradient(180deg, rgba(113,150,190,0.16), rgba(151,132,173,0.08) 58%, rgba(211,210,221,0.12))';
+
 export const AUTUMN_LEAF_CLIP_PATH =
     // Medium-length lobes preserve a maple silhouette without reading as a star.
     'polygon(47% 4%, 53% 4%, 58% 29%, 73% 22%, 77% 26%, 67% 46%, 88% 48%, 91% 53%, 68% 62%, 69% 82%, 63% 86%, 50% 71%, 37% 86%, 31% 82%, 32% 62%, 9% 53%, 12% 48%, 33% 46%, 23% 26%, 27% 22%, 42% 29%)';
@@ -18,6 +33,26 @@ const seasonalValue = (index: number, salt: number) => {
     const value = Math.sin(index * 12.9898 + salt * 78.233) * 43758.5453123;
     return value - Math.floor(value);
 };
+
+export type FlowerCloudyPetalSpec = {
+    left: number;
+    duration: number;
+    delay: number;
+    size: number;
+    drift: number;
+    rotate: number;
+};
+
+// The transition and final page share this exact dataset so flower-cloudy
+// petals keep their speed, position, and drift across the route boundary.
+export const FLOWER_CLOUDY_PETAL_SPECS: FlowerCloudyPetalSpec[] = Array.from({ length: 7 }, (_, index) => ({
+    left: seasonalValue(index, 21) * 100,
+    delay: seasonalValue(index, 22) * 4,
+    duration: 12 + seasonalValue(index, 23) * 7,
+    size: 7 + seasonalValue(index, 24) * 7,
+    drift: -42 + seasonalValue(index, 25) * 84,
+    rotate: seasonalValue(index, 26) * 360,
+}));
 
 export type AutumnLeafSpec = {
     left: number;

--- a/src/lib/otenkigurashiSeasonal.ts
+++ b/src/lib/otenkigurashiSeasonal.ts
@@ -1,0 +1,67 @@
+import type { CSSProperties } from 'react';
+
+export const AUTUMN_BACKGROUND_GRADIENT =
+    'linear-gradient(180deg, #c7ded9 0%, #f1e6ce 50%, #e4b36f 100%)';
+
+export const WINTER_BACKGROUND_GRADIENT =
+    'linear-gradient(180deg, #aebdcb 0%, #d8e4ec 48%, #ffffff 100%)';
+
+export const AUTUMN_LEAF_CLIP_PATH =
+    // Medium-length lobes preserve a maple silhouette without reading as a star.
+    'polygon(47% 4%, 53% 4%, 58% 29%, 73% 22%, 77% 26%, 67% 46%, 88% 48%, 91% 53%, 68% 62%, 69% 82%, 63% 86%, 50% 71%, 37% 86%, 31% 82%, 32% 62%, 9% 53%, 12% 48%, 33% 46%, 23% 26%, 27% 22%, 42% 29%)';
+
+export const AUTUMN_LEAF_FILTER = 'drop-shadow(0 2px 3px rgba(105,55,29,0.18))';
+export const AUTUMN_LEAF_OPACITY = 0.86;
+export const AUTUMN_LEAF_ANIMATION_NAME = 'otenki-momiji-fall';
+
+const seasonalValue = (index: number, salt: number) => {
+    const value = Math.sin(index * 12.9898 + salt * 78.233) * 43758.5453123;
+    return value - Math.floor(value);
+};
+
+export type AutumnLeafSpec = {
+    left: number;
+    duration: number;
+    delay: number;
+    size: number;
+    drift: number;
+    rotate: number;
+    tone: number;
+};
+
+// Both the final page and the route transition consume this same deterministic
+// dataset so leaves keep the same size, speed, color, and drift across the boundary.
+export const AUTUMN_LEAF_SPECS: AutumnLeafSpec[] = Array.from({ length: 20 }, (_, index) => {
+    const duration = 9 + seasonalValue(index, 13) * 7;
+
+    return {
+        left: seasonalValue(index, 11) * 100,
+        duration,
+        delay: -(seasonalValue(index, 12) * duration),
+        size: 13 + seasonalValue(index, 14) * 11,
+        drift: -42 + seasonalValue(index, 15) * 84,
+        rotate: seasonalValue(index, 16) * 360,
+        tone: seasonalValue(index, 17),
+    };
+});
+
+export const autumnLeafBackground = (tone: number) => tone > 0.6
+    ? 'linear-gradient(135deg, rgba(224,96,40,0.90), rgba(143,48,28,0.72))'
+    : tone > 0.28
+        ? 'linear-gradient(135deg, rgba(238,156,39,0.88), rgba(181,81,30,0.68))'
+        : 'linear-gradient(135deg, rgba(247,191,54,0.86), rgba(194,105,30,0.64))';
+
+export const autumnLeafStyle = (leaf: AutumnLeafSpec): CSSProperties => ({
+    left: `${leaf.left}%`,
+    top: '-8%',
+    width: leaf.size,
+    height: leaf.size * 0.92,
+    display: 'block',
+    clipPath: AUTUMN_LEAF_CLIP_PATH,
+    background: autumnLeafBackground(leaf.tone),
+    filter: AUTUMN_LEAF_FILTER,
+    transform: `rotate(${leaf.rotate}deg)`,
+    opacity: AUTUMN_LEAF_OPACITY,
+    animation: `${AUTUMN_LEAF_ANIMATION_NAME} ${leaf.duration}s linear ${leaf.delay}s infinite`,
+    ['--autumn-drift' as string]: `${leaf.drift}px`,
+});

--- a/src/lib/seasonResolver.test.ts
+++ b/src/lib/seasonResolver.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSeasonState } from './seasonResolver';
+
+const japanDate = (date: string) => new Date(`${date}T03:00:00.000Z`);
+
+describe('resolveSeasonState', () => {
+    it('resolves the regular season boundaries', () => {
+        expect(resolveSeasonState(japanDate('2026-03-01'))).toEqual({ season: 'spring', seasonEvent: 'none' });
+        expect(resolveSeasonState(japanDate('2026-06-06'))).toEqual({ season: 'summer', seasonEvent: 'none' });
+        expect(resolveSeasonState(japanDate('2026-06-07')).season).toBe('summer');
+        expect(resolveSeasonState(japanDate('2026-09-01'))).toEqual({ season: 'autumn', seasonEvent: 'none' });
+        expect(resolveSeasonState(japanDate('2026-12-01'))).toEqual({ season: 'winter', seasonEvent: 'none' });
+    });
+
+    it('gives geshi precedence over the tsuyu atmosphere on the solstice', () => {
+        expect(resolveSeasonState(japanDate('2026-06-21'))).toEqual({ season: 'summer', seasonEvent: 'geshi' });
+    });
+
+    it('keeps tsuyu inside its intended date range', () => {
+        expect(resolveSeasonState(japanDate('2026-06-20')).seasonEvent).toBe('tsuyu');
+        expect(resolveSeasonState(japanDate('2026-07-20')).seasonEvent).toBe('tsuyu');
+        expect(resolveSeasonState(japanDate('2026-07-21')).seasonEvent).toBe('none');
+    });
+});

--- a/src/lib/seasonResolver.ts
+++ b/src/lib/seasonResolver.ts
@@ -1,0 +1,49 @@
+import type { SeasonEventType, SeasonType } from '@/store';
+
+export type ResolvedSeasonState = {
+    season: SeasonType;
+    seasonEvent: SeasonEventType;
+};
+
+type JapanDateParts = {
+    month: number;
+    day: number;
+};
+
+function getJapanDateParts(date: Date): JapanDateParts {
+    const parts = new Intl.DateTimeFormat('en-US', {
+        timeZone: 'Asia/Tokyo',
+        month: 'numeric',
+        day: 'numeric',
+    }).formatToParts(date);
+
+    return {
+        month: Number(parts.find((part) => part.type === 'month')?.value ?? 1),
+        day: Number(parts.find((part) => part.type === 'day')?.value ?? 1),
+    };
+}
+
+function resolveSeason(month: number): SeasonType {
+    if (month >= 3 && month <= 5) return 'spring';
+    if (month >= 6 && month <= 8) return 'summer';
+    if (month >= 9 && month <= 11) return 'autumn';
+    return 'winter';
+}
+
+function resolveSeasonEvent(month: number, day: number): SeasonEventType {
+    // 夏至は梅雨の雰囲気より優先して、専用の演出を選ぶ。
+    if (month === 6 && day === 21) return 'geshi';
+
+    // 梅雨は日本の季節感に合わせた固定期間で表現する。
+    if ((month === 6 && day >= 7) || (month === 7 && day <= 20)) return 'tsuyu';
+
+    return 'none';
+}
+
+export function resolveSeasonState(date = new Date()): ResolvedSeasonState {
+    const { month, day } = getJapanDateParts(date);
+    return {
+        season: resolveSeason(month),
+        seasonEvent: resolveSeasonEvent(month, day),
+    };
+}

--- a/src/lib/worldState.test.ts
+++ b/src/lib/worldState.test.ts
@@ -9,6 +9,13 @@ describe('parseWorldStateRecord', () => {
         });
     });
 
+    it('clears tsuyu when the route explicitly selects spring', () => {
+        expect(parseWorldStateRecord({ season: 'spring', seasonEvent: 'tsuyu' })).toEqual({
+            season: 'spring',
+            seasonEvent: 'none',
+        });
+    });
+
     it('keeps tsuyu for an explicitly selected summer route', () => {
         expect(parseWorldStateRecord({ season: 'summer', seasonEvent: 'tsuyu' })).toEqual({
             season: 'summer',

--- a/src/lib/worldState.test.ts
+++ b/src/lib/worldState.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { parseWorldStateRecord } from './worldState';
+
+describe('parseWorldStateRecord', () => {
+    it('clears tsuyu when the route explicitly selects a non-summer season', () => {
+        expect(parseWorldStateRecord({ season: 'autumn', seasonEvent: 'tsuyu' })).toEqual({
+            season: 'autumn',
+            seasonEvent: 'none',
+        });
+    });
+
+    it('keeps tsuyu for an explicitly selected summer route', () => {
+        expect(parseWorldStateRecord({ season: 'summer', seasonEvent: 'tsuyu' })).toEqual({
+            season: 'summer',
+            seasonEvent: 'tsuyu',
+        });
+    });
+});

--- a/src/lib/worldState.ts
+++ b/src/lib/worldState.ts
@@ -20,13 +20,18 @@ export function parseWorldStateRecord(source: SearchRecord): Partial<WorldState>
     const weather = firstValue(source.weather);
     const season = firstValue(source.season);
     const seasonEvent = firstValue(source.seasonEvent);
+    const parsedSeason = season && VALID_SEASONS.includes(season as SeasonType) ? season as SeasonType : null;
+    const parsedSeasonEvent = seasonEvent && VALID_SEASON_EVENTS.includes(seasonEvent as SeasonEventType)
+        ? seasonEvent as SeasonEventType
+        : null;
+    const normalizedSeasonEvent = parsedSeasonEvent === 'tsuyu' && parsedSeason && parsedSeason !== 'summer'
+        ? 'none'
+        : parsedSeasonEvent;
 
     return {
         ...(weather && VALID_WEATHERS.includes(weather as WeatherType) ? { weather: weather as WeatherType } : {}),
-        ...(season && VALID_SEASONS.includes(season as SeasonType) ? { season: season as SeasonType } : {}),
-        ...(seasonEvent && VALID_SEASON_EVENTS.includes(seasonEvent as SeasonEventType)
-            ? { seasonEvent: seasonEvent as SeasonEventType }
-            : {}),
+        ...(parsedSeason ? { season: parsedSeason } : {}),
+        ...(normalizedSeasonEvent ? { seasonEvent: normalizedSeasonEvent } : {}),
     };
 }
 

--- a/src/lib/worldState.ts
+++ b/src/lib/worldState.ts
@@ -1,0 +1,48 @@
+import type { SeasonEventType, SeasonType, WeatherType } from '@/store';
+
+export const VALID_WEATHERS: WeatherType[] = ['Clear', 'Rain', 'Clouds', 'Snow', 'Night', 'Morning', 'Thunder'];
+export const VALID_SEASONS: SeasonType[] = ['none', 'spring', 'summer', 'autumn', 'winter'];
+export const VALID_SEASON_EVENTS: SeasonEventType[] = ['none', 'geshi', 'tsuyu'];
+
+export type WorldState = {
+    weather: WeatherType;
+    season: SeasonType;
+    seasonEvent: SeasonEventType;
+};
+
+type SearchValue = string | string[] | undefined | null;
+type SearchRecord = Record<string, SearchValue>;
+type SearchParamsLike = { get: (name: string) => string | null };
+
+const firstValue = (value: SearchValue) => Array.isArray(value) ? value[0] : value ?? null;
+
+export function parseWorldStateRecord(source: SearchRecord): Partial<WorldState> {
+    const weather = firstValue(source.weather);
+    const season = firstValue(source.season);
+    const seasonEvent = firstValue(source.seasonEvent);
+
+    return {
+        ...(weather && VALID_WEATHERS.includes(weather as WeatherType) ? { weather: weather as WeatherType } : {}),
+        ...(season && VALID_SEASONS.includes(season as SeasonType) ? { season: season as SeasonType } : {}),
+        ...(seasonEvent && VALID_SEASON_EVENTS.includes(seasonEvent as SeasonEventType)
+            ? { seasonEvent: seasonEvent as SeasonEventType }
+            : {}),
+    };
+}
+
+export function parseWorldStateParams(source: SearchParamsLike): Partial<WorldState> {
+    return parseWorldStateRecord({
+        weather: source.get('weather'),
+        season: source.get('season'),
+        seasonEvent: source.get('seasonEvent'),
+    });
+}
+
+export function buildWorldStateQuery(state: WorldState, lang?: string) {
+    const params = new URLSearchParams();
+    if (lang) params.set('lang', lang);
+    params.set('weather', state.weather);
+    params.set('season', state.season);
+    params.set('seasonEvent', state.seasonEvent);
+    return params.toString();
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 
 export type WeatherType = 'Clear' | 'Rain' | 'Clouds' | 'Snow' | 'Night' | 'Morning' | 'Thunder';
 export type SeasonType = 'none' | 'spring' | 'summer' | 'autumn' | 'winter';
-export type SeasonEventType = 'none' | 'geshi';
+export type SeasonEventType = 'none' | 'geshi' | 'tsuyu';
 
 interface AppState {
     weather: WeatherType;


### PR DESCRIPTION
## 概要

天候・季節イベントを作品間で引き継げるようにし、季節演出と遷移演出の不一致を整理しました。

- 日本時間ベースの季節・イベント resolver と共有 World State を追加
- 梅雨（tsuyu）の晴れ・曇り・雨向け背景と遷移演出を追加
- 梅雨演出を夏季限定に統一し、不正な季節イベント組み合わせを正規化
- 遷移中と遷移後で季節演出のトークン・粒子仕様を共有
- てんちゃんに雨粒・稲妻・夜星アクセサリーを追加
- 伝承魚の Snow 時だけマリンスノーを表示
- 月相の新月付近で視認性が崩れない表示へ補正
- 天候別の回帰テストを追加

## 単一責任コミット

- `feat(world-state): 季節イベントと作品間の状態同期を共通化`
- `fix(otenkigurashi): 新月付近の月表示を安定させる`
- `feat(otenkigurashi): 天候別てんちゃんアクセサリーを追加`
- `feat(otenkigurashi): 梅雨と季節遷移の演出を統一`
- `feat(denshouo): 雪天のマリンスノー演出を追加`
- `test(weather): 天候別季節演出の回帰テストを追加`
- `fix(world-state): 梅雨イベントの季節組み合わせを正規化`
- `fix(otenkigurashi): 梅雨演出を夏季限定に統一`

## 検証

- `npx tsc --noEmit` ✅
- `npx vitest run src/lib/worldState.test.ts src/lib/seasonResolver.test.ts` ✅（6 tests）
- `git diff --check` ✅
- Playwright E2E は Chromium 起動時の環境権限エラー（EPERM）のため未実行

## Issue

Closes #3
Closes #5
Closes #6
Closes #7

#8（TIME MACHINE）は `not planned` でクローズ済みです。#4・#2・#9 は今回のスコープ外です。