### PR TITLE
fix: 遷移・季節状態・WebGLの失敗パターンを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@
 /.codex/
 
 # local GIF capture/build artifacts
+/tmp/
+/output/
 /tmp/*.py
 /tmp/*.js
 /tmp/*.mjs

--- a/src/app/denshouo/DenshouoAtmosphere.tsx
+++ b/src/app/denshouo/DenshouoAtmosphere.tsx
@@ -2,7 +2,7 @@
 
 import { motion, useReducedMotion } from 'framer-motion';
 import { Canvas, useFrame } from '@react-three/fiber';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { Component, useEffect, useMemo, useRef, useState, type ErrorInfo, type ReactNode } from 'react';
 import * as THREE from 'three';
 import type { WeatherType } from '@/store';
 import { waveVertexShader, waveFragmentShader } from '@/shaders/wave';
@@ -678,6 +678,25 @@ function OceanRainEffects() {
     );
 }
 
+type WebGLBoundaryProps = { children: ReactNode; fallback: ReactNode };
+type WebGLBoundaryState = { hasError: boolean };
+
+class WebGLBoundary extends Component<WebGLBoundaryProps, WebGLBoundaryState> {
+    state: WebGLBoundaryState = { hasError: false };
+
+    static getDerivedStateFromError(): WebGLBoundaryState {
+        return { hasError: true };
+    }
+
+    componentDidCatch(error: Error, info: ErrorInfo) {
+        console.warn('[Denshouo] WebGL disabled; using CSS fallback.', error, info);
+    }
+
+    render() {
+        return this.state.hasError ? this.props.fallback : this.props.children;
+    }
+}
+
 function OceanBackdrop({ weather }: { weather: WeatherType }) {
     const isRain = weather === 'Rain';
     const isSnow = weather === 'Snow';
@@ -688,11 +707,13 @@ function OceanBackdrop({ weather }: { weather: WeatherType }) {
 
             {webglSupported && (
                 <div className="fixed inset-0 pointer-events-none z-1">
-                    <Canvas camera={{ position: [0, 0, 0], fov: 75 }}>
-                        <color attach="background" args={['#041116']} />
-                        <OceanSurface />
-                        <OceanBubbles />
-                    </Canvas>
+                    <WebGLBoundary fallback={null}>
+                        <Canvas camera={{ position: [0, 0, 0], fov: 75 }}>
+                            <color attach="background" args={['#041116']} />
+                            <OceanSurface />
+                            <OceanBubbles />
+                        </Canvas>
+                    </WebGLBoundary>
                 </div>
             )}
 
@@ -777,4 +798,3 @@ function OceanBackdrop({ weather }: { weather: WeatherType }) {
 }
 
 export { FishCursor, OceanBackdrop };
-

--- a/src/components/ClientInitializer.tsx
+++ b/src/components/ClientInitializer.tsx
@@ -16,17 +16,17 @@ export default function ClientInitializer({
     initialSeasonEvent?: SeasonEventType;
     initialActivity: number;
 }) {
-    const { setWorldState, setActivity, setActiveWork } = useStore();
+    const { initializeWorldState, setActivity, setActiveWork } = useStore();
 
     useIsomorphicLayoutEffect(() => {
-        setWorldState({
+        initializeWorldState({
             weather: initialWeather,
             ...(initialSeason ? { season: initialSeason } : {}),
             ...(initialSeasonEvent ? { seasonEvent: initialSeasonEvent } : {}),
         });
         setActivity(initialActivity);
         setActiveWork(null);
-    }, [initialActivity, initialSeason, initialSeasonEvent, initialWeather, setActiveWork, setActivity, setWorldState]);
+    }, [initialActivity, initialSeason, initialSeasonEvent, initialWeather, initializeWorldState, setActiveWork, setActivity]);
 
     return null;
 }

--- a/src/components/SoundDirector.tsx
+++ b/src/components/SoundDirector.tsx
@@ -16,6 +16,23 @@ import {
   resolveAudioWorkId,
 } from "@/lib/soundProfile";
 
+function readMutedPreference() {
+  try {
+    return window.localStorage.getItem(MUTE_KEY);
+  } catch {
+    // Storage can be unavailable in private browsing or locked-down embeds.
+    return null;
+  }
+}
+
+function writeMutedPreference(muted: boolean) {
+  try {
+    window.localStorage.setItem(MUTE_KEY, muted ? "1" : "0");
+  } catch {
+    // Audio should keep working even when the preference cannot be persisted.
+  }
+}
+
 export default function SoundDirector() {
   const pathname = usePathname();
   const transitionType = useStore((state) => state.transitionType);
@@ -518,7 +535,7 @@ export default function SoundDirector() {
   const setMutedState = async (nextMuted: boolean) => {
     isMutedRef.current = nextMuted;
     setIsMuted(nextMuted);
-    window.localStorage.setItem(MUTE_KEY, nextMuted ? "1" : "0");
+    writeMutedPreference(nextMuted);
 
     const ok = await ensureAudioGraph();
     if (!ok) return;
@@ -550,7 +567,7 @@ export default function SoundDirector() {
     if (isCardPage) return;
     if (typeof window === "undefined") return;
 
-    const savedMuted = window.localStorage.getItem(MUTE_KEY);
+    const savedMuted = readMutedPreference();
     isMutedRef.current = savedMuted === null ? true : savedMuted === "1";
     setIsMuted(isMutedRef.current);
 

--- a/src/components/WorldStateProvider.tsx
+++ b/src/components/WorldStateProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useContext, useEffect, useMemo, type ReactNode } from 'react';
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useStore } from '@/store';
 import { parseWorldStateParams, resolveWorldState } from '@/lib/worldState';
@@ -15,38 +15,64 @@ export default function WorldStateProvider({ children }: { children: ReactNode }
     const storeWeather = useStore((state) => state.weather);
     const storeSeason = useStore((state) => state.season);
     const storeSeasonEvent = useStore((state) => state.seasonEvent);
+    const seasonResolution = useStore((state) => state.seasonResolution);
+    const seasonEventResolution = useStore((state) => state.seasonEventResolution);
     const setWorldState = useStore((state) => state.setWorldState);
     const routeWorldState = useMemo(
         () => parseWorldStateParams(new URLSearchParams(searchParamsKey)),
         [searchParamsKey],
     );
-    const fallbackSeasonState = useMemo(() => resolveSeasonState(), []);
+    const [seasonClockKey, setSeasonClockKey] = useState(() => getJapanDayKey());
+
+    useEffect(() => {
+        const timer = window.setInterval(() => {
+            const nextKey = getJapanDayKey();
+            setSeasonClockKey((currentKey) => currentKey === nextKey ? currentKey : nextKey);
+        }, 60_000);
+        return () => window.clearInterval(timer);
+    }, []);
+
+    const fallbackSeasonState = useMemo(
+        () => resolveSeasonState(new Date(`${seasonClockKey}T00:00:00+09:00`)),
+        [seasonClockKey],
+    );
 
     const worldState = useMemo(() => resolveWorldState(
         routeWorldState,
         {
             weather: storeWeather,
-            season: storeSeason === 'none' ? fallbackSeasonState.season : storeSeason,
-            seasonEvent: storeSeasonEvent === 'none' ? fallbackSeasonState.seasonEvent : storeSeasonEvent,
+            season: seasonResolution === 'auto' ? fallbackSeasonState.season : storeSeason,
+            seasonEvent: seasonEventResolution === 'auto' ? fallbackSeasonState.seasonEvent : storeSeasonEvent,
         },
-    ), [fallbackSeasonState, routeWorldState, storeSeason, storeSeasonEvent, storeWeather]);
+    ), [fallbackSeasonState, routeWorldState, seasonEventResolution, seasonResolution, storeSeason, storeSeasonEvent, storeWeather]);
 
     useEffect(() => {
         const nextWorldState = {
-            ...(routeWorldState.weather && routeWorldState.weather !== storeWeather ? { weather: routeWorldState.weather } : {}),
-            ...(routeWorldState.season && routeWorldState.season !== storeSeason ? { season: routeWorldState.season } : {}),
-            ...(routeWorldState.seasonEvent && routeWorldState.seasonEvent !== storeSeasonEvent ? { seasonEvent: routeWorldState.seasonEvent } : {}),
+            ...(routeWorldState.weather ? { weather: routeWorldState.weather } : {}),
+            ...(routeWorldState.season ? { season: routeWorldState.season } : {}),
+            ...(routeWorldState.seasonEvent ? { seasonEvent: routeWorldState.seasonEvent } : {}),
         };
         if (Object.keys(nextWorldState).length > 0) {
             setWorldState(nextWorldState);
         }
-    }, [routeWorldState.season, routeWorldState.seasonEvent, routeWorldState.weather, setWorldState, storeSeason, storeSeasonEvent, storeWeather]);
+    }, [routeWorldState.season, routeWorldState.seasonEvent, routeWorldState.weather, setWorldState]);
 
     return (
         <WorldStateContext.Provider value={worldState}>
             {children}
         </WorldStateContext.Provider>
     );
+}
+
+function getJapanDayKey() {
+    const parts = new Intl.DateTimeFormat('en-US', {
+        timeZone: 'Asia/Tokyo',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+    }).formatToParts(new Date());
+    const values = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+    return `${values.year}-${values.month}-${values.day}`;
 }
 
 export function useWorldState(): WorldState {

--- a/src/components/dom/TopLeftMenu.tsx
+++ b/src/components/dom/TopLeftMenu.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useRouter } from 'next/navigation';
 import { useStore, type SeasonEventType, type SeasonType, type WeatherType } from '@/store';
-import { buildWorldStateQuery } from '@/lib/worldState';
+import { useWorkNavigation } from './useWorkNavigation';
 
 const MENU_COMMANDS = {
     ja: [
@@ -40,80 +40,23 @@ export default function TopLeftMenu() {
     const router = useRouter();
     const searchParams = useSearchParams();
     const lang = searchParams.get('lang') === 'en' ? 'en' : 'ja';
-    const { setActiveWork, setTransitionType, setWorldState } = useStore();
+    const setWorldState = useStore((state) => state.setWorldState);
+    const navigateToWork = useWorkNavigation(lang);
     const commands = MENU_COMMANDS[lang];
     const withLang = (href: string) => `${href}?lang=${lang}`;
 
     const navigateWithTransition = (href: string) => {
         setOpen(false);
 
-        if (href === '/github-planet') {
-            setActiveWork('01');
-            setTransitionType('warp');
-            setTimeout(() => {
-                router.push(withLang('/github-planet'));
-                setTimeout(() => setTransitionType('none'), 1000);
-            }, 1400);
-            return;
-        }
-
-        if (href === '/otenkigurashi') {
-            setActiveWork('02');
-            const { weather: currentWeather, season: currentSeason, seasonEvent: currentSeasonEvent } = useStore.getState();
-            const otenkiHref = `/otenkigurashi?${buildWorldStateQuery({ weather: currentWeather, season: currentSeason, seasonEvent: currentSeasonEvent }, lang)}`;
-
-            if (currentWeather === 'Rain') {
-                setTransitionType('rain');
-            } else if (currentWeather === 'Snow') {
-                setTransitionType('snow');
-            } else if (currentWeather === 'Thunder') {
-                setTransitionType('flash');
-            } else if (currentWeather === 'Clouds') {
-                setTransitionType('heavy-cloud');
-            } else if (currentWeather === 'Clear' || currentWeather === 'Morning') {
-                setTransitionType('sunburst');
-            } else {
-                setTransitionType('moonrise');
-            }
-            setTimeout(() => {
-                router.push(otenkiHref);
-                setTimeout(() => setTransitionType('none'), 1000);
-            }, 2000);
-            return;
-        }
-
-        if (href === '/coldkeep') {
-            setActiveWork('03');
-            setTransitionType('freeze');
-            setTimeout(() => {
-                router.push(withLang('/coldkeep'));
-                setTimeout(() => setTransitionType('none'), 1000);
-            }, 2000);
-            return;
-        }
-
-        if (href === '/recaptcha-game') {
-            setActiveWork('04');
-            setTransitionType('captcha-lock');
-            setTimeout(() => {
-                router.push(withLang('/recaptcha-game'));
-                setTimeout(() => setTransitionType('none'), 900);
-            }, 1650);
-            return;
-        }
-
-        if (href === '/denshouo') {
-            setActiveWork('05');
-            setTransitionType('wave');
-            const { weather: currentWeather } = useStore.getState();
-            const { season: currentSeason, seasonEvent: currentSeasonEvent } = useStore.getState();
-            const denshouoHref = `/denshouo?${buildWorldStateQuery({ weather: currentWeather, season: currentSeason, seasonEvent: currentSeasonEvent }, lang)}`;
-            setTimeout(() => {
-                router.push(denshouoHref);
-                setTimeout(() => setTransitionType('none'), 900);
-            }, 1800);
-            return;
-        }
+        const workIds: Record<string, '01' | '02' | '03' | '04' | '05'> = {
+            '/github-planet': '01',
+            '/otenkigurashi': '02',
+            '/coldkeep': '03',
+            '/recaptcha-game': '04',
+            '/denshouo': '05',
+        };
+        const workId = workIds[href];
+        if (workId && navigateToWork(workId)) return;
 
         router.push(withLang(href));
     };

--- a/src/components/dom/WorksList.tsx
+++ b/src/components/dom/WorksList.tsx
@@ -1,9 +1,7 @@
 'use client'
 
-import { useStore } from '@/store';
-import { buildWorldStateQuery } from '@/lib/worldState';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useWorkNavigation } from './useWorkNavigation';
 
 interface Work {
     id: string;
@@ -13,76 +11,12 @@ interface Work {
 }
 
 export default function WorksList({ works }: { works: Work[] }) {
-    const { setActiveWork, activeWorkId, setTransitionType } = useStore();
-    const router = useRouter();
     const searchParams = useSearchParams();
     const lang = searchParams.get('lang') === 'en' ? 'en' : 'ja';
-    const withLang = (path: string) => `${path}?lang=${lang}`;
-
-    useEffect(() => {
-        // ... (スクロール無効化はGlobalTransitionOverlayに移動したので削除)
-    }, []);
+    const navigateToWork = useWorkNavigation(lang);
 
     const handleWorkClick = (id: string) => {
-        if (id === '01') {
-            setActiveWork('01');
-            setTransitionType('warp');
-            setTimeout(() => {
-                router.push(withLang('/github-planet'));
-                // 次のページが表示され、オーバレイがフェードアウトする時間を確保するため少し長めに待つ
-                setTimeout(() => setTransitionType('none'), 1000);
-            }, 1400);
-        } else if (id === '02') {
-            setActiveWork('02');
-            const { weather: currentWeather, season: currentSeason, seasonEvent: currentSeasonEvent } = useStore.getState();
-            const otenkiHref = `/otenkigurashi?${buildWorldStateQuery({ weather: currentWeather, season: currentSeason, seasonEvent: currentSeasonEvent }, lang)}`;
-
-            // 天候に応じて遷移アニメーションを分岐
-            if (currentWeather === 'Rain') {
-                setTransitionType('rain');
-            } else if (currentWeather === 'Snow') {
-                setTransitionType('snow');
-            } else if (currentWeather === 'Thunder') {
-                setTransitionType('flash');
-            } else if (currentWeather === 'Clouds') {
-                setTransitionType('heavy-cloud');
-            } else if (currentWeather === 'Clear' || currentWeather === 'Morning') {
-                setTransitionType('sunburst');
-            } else {
-                setTransitionType('moonrise'); // Night
-            }
-
-            setTimeout(() => {
-                router.push(otenkiHref);
-                setTimeout(() => setTransitionType('none'), 1000);
-            }, 2000);
-        } else if (id === '03') {
-            setActiveWork('03');
-            setTransitionType('freeze');
-            setTimeout(() => {
-                router.push(withLang('/coldkeep'));
-                setTimeout(() => setTransitionType('none'), 1000);
-            }, 2000);
-        } else if (id === '04') {
-            setActiveWork('04');
-            setTransitionType('captcha-lock');
-            setTimeout(() => {
-                router.push(withLang('/recaptcha-game'));
-                setTimeout(() => setTransitionType('none'), 900);
-            }, 1650);
-        } else if (id === '05') {
-            setActiveWork('05');
-            setTransitionType('wave');
-            const { weather: currentWeather } = useStore.getState();
-            const { season: currentSeason, seasonEvent: currentSeasonEvent } = useStore.getState();
-            const denshouoHref = `/denshouo?${buildWorldStateQuery({ weather: currentWeather, season: currentSeason, seasonEvent: currentSeasonEvent }, lang)}`;
-            setTimeout(() => {
-                router.push(denshouoHref);
-                setTimeout(() => setTransitionType('none'), 900);
-            }, 1800);
-        } else {
-            setActiveWork(activeWorkId === id ? null : id);
-        }
+        navigateToWork(id);
     };
 
     return (

--- a/src/components/dom/useWorkNavigation.ts
+++ b/src/components/dom/useWorkNavigation.ts
@@ -1,0 +1,121 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useRef } from 'react';
+import { buildWorldStateQuery } from '@/lib/worldState';
+import { type TransitionType } from '@/lib/soundProfile';
+import { useStore } from '@/store';
+
+type WorkId = '01' | '02' | '03' | '04' | '05';
+
+type NavigationPlan = {
+    path: string;
+    transition: Exclude<TransitionType, 'none'>;
+    routeDelay: number;
+    clearDelay: number;
+};
+
+const STATIC_PLANS: Record<Exclude<WorkId, '02' | '05'>, Omit<NavigationPlan, 'path'>> = {
+    '01': { transition: 'warp', routeDelay: 1400, clearDelay: 1000 },
+    '03': { transition: 'freeze', routeDelay: 2000, clearDelay: 1000 },
+    '04': { transition: 'captcha-lock', routeDelay: 1650, clearDelay: 900 },
+};
+
+export function useWorkNavigation(lang: 'ja' | 'en') {
+    const router = useRouter();
+    const setActiveWork = useStore((state) => state.setActiveWork);
+    const setTransitionType = useStore((state) => state.setTransitionType);
+    const timersRef = useRef<number[]>([]);
+    const navigationVersionRef = useRef(0);
+
+    const clearTimers = useCallback(() => {
+        timersRef.current.forEach((timer) => window.clearTimeout(timer));
+        timersRef.current = [];
+        navigationVersionRef.current += 1;
+    }, []);
+
+    useEffect(() => clearTimers, [clearTimers]);
+
+    const navigateToWork = useCallback((workId: string) => {
+        if (!isWorkId(workId)) return false;
+
+        const currentState = useStore.getState();
+        const plan = getNavigationPlan(workId, lang, currentState);
+        if (!plan) return false;
+
+        clearTimers();
+        const navigationVersion = navigationVersionRef.current;
+        setActiveWork(workId);
+        setTransitionType(plan.transition);
+
+        const routeTimer = window.setTimeout(() => {
+            router.push(plan.path);
+
+            const clearTimer = window.setTimeout(() => {
+                // A newer navigation may already own the overlay. Never clear it
+                // from an older route's timer.
+                if (
+                    navigationVersionRef.current === navigationVersion
+                    && useStore.getState().transitionType === plan.transition
+                ) {
+                    setTransitionType('none');
+                }
+            }, plan.clearDelay);
+            timersRef.current.push(clearTimer);
+        }, plan.routeDelay);
+
+        timersRef.current.push(routeTimer);
+        return true;
+    }, [clearTimers, lang, router, setActiveWork, setTransitionType]);
+
+    return navigateToWork;
+}
+
+function isWorkId(value: string): value is WorkId {
+    return value === '01' || value === '02' || value === '03' || value === '04' || value === '05';
+}
+
+function getNavigationPlan(
+    workId: WorkId,
+    lang: 'ja' | 'en',
+    state: ReturnType<typeof useStore.getState>,
+): NavigationPlan | null {
+    if (workId === '02') {
+        const transition = state.weather === 'Rain'
+            ? 'rain'
+            : state.weather === 'Snow'
+                ? 'snow'
+                : state.weather === 'Thunder'
+                    ? 'flash'
+                    : state.weather === 'Clouds'
+                        ? 'heavy-cloud'
+                        : state.weather === 'Clear' || state.weather === 'Morning'
+                            ? 'sunburst'
+                            : 'moonrise';
+
+        return {
+            path: `/otenkigurashi?${buildWorldStateQuery({ weather: state.weather, season: state.season, seasonEvent: state.seasonEvent }, lang)}`,
+            transition,
+            routeDelay: 2000,
+            clearDelay: 1000,
+        };
+    }
+
+    if (workId === '05') {
+        return {
+            path: `/denshouo?${buildWorldStateQuery({ weather: state.weather, season: state.season, seasonEvent: state.seasonEvent }, lang)}`,
+            transition: 'wave',
+            routeDelay: 1800,
+            clearDelay: 900,
+        };
+    }
+
+    const staticPlan = STATIC_PLANS[workId];
+    const paths: Record<Exclude<WorkId, '02' | '05'>, string> = {
+        '01': `/github-planet?lang=${lang}`,
+        '03': `/coldkeep?lang=${lang}`,
+        '04': `/recaptcha-game?lang=${lang}`,
+    };
+
+    return { path: paths[workId], ...staticPlan };
+}

--- a/src/store/index.test.ts
+++ b/src/store/index.test.ts
@@ -4,7 +4,11 @@ import { useStore } from './index';
 const DEFAULT_STATE = { weather: 'Clear' as const, season: 'none' as const, seasonEvent: 'none' as const };
 
 afterEach(() => {
-    useStore.getState().setWorldState(DEFAULT_STATE);
+    useStore.setState({
+        ...DEFAULT_STATE,
+        seasonResolution: 'auto',
+        seasonEventResolution: 'auto',
+    });
 });
 
 describe('world state store', () => {
@@ -33,5 +37,25 @@ describe('world state store', () => {
 
         useStore.getState().setWorldState({ weather: 'Rain' });
         expect(useStore.getState().seasonEvent).toBe('none');
+    });
+
+    it('keeps an explicit season clear separate from automatic resolution', () => {
+        useStore.getState().setWorldState({ season: 'none', seasonEvent: 'none' });
+
+        expect(useStore.getState()).toMatchObject({
+            season: 'none',
+            seasonEvent: 'none',
+            seasonResolution: 'manual',
+            seasonEventResolution: 'manual',
+        });
+    });
+
+    it('does not turn server initialization into a manual override', () => {
+        useStore.getState().initializeWorldState({ season: 'winter' });
+
+        expect(useStore.getState()).toMatchObject({
+            season: 'winter',
+            seasonResolution: 'auto',
+        });
     });
 });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -8,6 +8,8 @@ interface AppState {
     weather: WeatherType;
     season: SeasonType;
     seasonEvent: SeasonEventType;
+    seasonResolution: 'auto' | 'manual';
+    seasonEventResolution: 'auto' | 'manual';
     githubActivityLevel: number;
     activeWorkId: string | null;
     transitionType: 'none' | 'warp' | 'cloud' | 'freeze' | 'rain' | 'snow' | 'sunburst' | 'flash' | 'heavy-cloud' | 'wave' | 'moonrise' | 'captcha-lock';
@@ -15,6 +17,7 @@ interface AppState {
     setSeason: (season: SeasonType) => void;
     setSeasonEvent: (seasonEvent: SeasonEventType) => void;
     setWorldState: (state: Partial<WorldState>) => void;
+    initializeWorldState: (state: Partial<WorldState>) => void;
     setActivity: (level: number) => void;
     setActiveWork: (id: string | null) => void;
     setTransitionType: (type: 'none' | 'warp' | 'cloud' | 'freeze' | 'rain' | 'snow' | 'sunburst' | 'flash' | 'heavy-cloud' | 'wave' | 'moonrise' | 'captcha-lock') => void;
@@ -25,6 +28,8 @@ export const useStore = create<AppState>((set) => ({
     weather: 'Clear',
     season: 'none',
     seasonEvent: 'none',
+    seasonResolution: 'auto',
+    seasonEventResolution: 'auto',
     githubActivityLevel: 0.5,
     activeWorkId: null,
     transitionType: 'none',
@@ -33,17 +38,32 @@ export const useStore = create<AppState>((set) => ({
         season: current.season,
         seasonEvent: current.seasonEvent,
     })),
-    setSeason: (season) => set((current) => normalizeWorldState({
-        weather: current.weather,
-        season,
-        seasonEvent: current.seasonEvent,
+    setSeason: (season) => set((current) => ({
+        ...normalizeWorldState({
+            weather: current.weather,
+            season,
+            seasonEvent: current.seasonEvent,
+        }),
+        seasonResolution: 'manual',
     })),
-    setSeasonEvent: (seasonEvent) => set((current) => normalizeWorldState({
-        weather: current.weather,
-        season: current.season,
-        seasonEvent,
+    setSeasonEvent: (seasonEvent) => set((current) => ({
+        ...normalizeWorldState({
+            weather: current.weather,
+            season: current.season,
+            seasonEvent,
+        }),
+        seasonEventResolution: 'manual',
     })),
-    setWorldState: (next) => set((current) => normalizeWorldState({
+    setWorldState: (next) => set((current) => ({
+        ...normalizeWorldState({
+            weather: next.weather ?? current.weather,
+            season: next.season ?? current.season,
+            seasonEvent: next.seasonEvent ?? current.seasonEvent,
+        }),
+        seasonResolution: next.season === undefined ? current.seasonResolution : 'manual',
+        seasonEventResolution: next.seasonEvent === undefined ? current.seasonEventResolution : 'manual',
+    })),
+    initializeWorldState: (next) => set((current) => normalizeWorldState({
         weather: next.weather ?? current.weather,
         season: next.season ?? current.season,
         seasonEvent: next.seasonEvent ?? current.seasonEvent,


### PR DESCRIPTION
## 概要
レビューで見つかった、画面が固まる・季節指定が戻る・遷移が競合する問題を修正します。

## 変更内容
- 手動の季節／季節イベント指定と自動日付判定を分離
- 日付を跨いだときに日本時間で季節判定を更新
- 作品遷移のタイマーを共通化し、連打時の古いタイマーを無効化
- でんしょうおのWebGL生成失敗をError BoundaryでCSS表示へフォールバック
- localStorageが利用できない環境でも音声処理を継続
- `tmp/` と `output/` をGit管理外に追加

## 根本原因
- `none` を自動判定と手動解除の両方に使っていた
- WebGLの事前検査だけではCanvas生成失敗を防げなかった
- 作品一覧とメニューに遷移タイマーが重複していた

## 検証
- `npx tsc --noEmit`
- 関連Vitest 15件
- 対象ファイルのESLint
- `npm run build`
