### PR TITLE
refactor: canonical seasonal world state and transition visuals

### DIFF
--- a/e2e/otenkigurashi-weather.spec.ts
+++ b/e2e/otenkigurashi-weather.spec.ts
@@ -4,8 +4,11 @@ const route = (weather: string, season = 'none', seasonEvent = 'none') =>
     `/otenkigurashi?lang=ja&weather=${weather}&season=${season}&seasonEvent=${seasonEvent}`;
 
 const revealTenchan = async (page: Page) => {
+    // domcontentloaded can precede hydration on this intentionally heavy page.
+    // Give the controller time to install its first-interaction listener.
+    await page.waitForTimeout(500);
     await page.mouse.click(100, 100);
-    await expect(page.locator('[data-testid="tenchan-companion"]')).toHaveCount(1, { timeout: 5000 });
+    await expect(page.locator('[data-testid="tenchan-companion"]')).toHaveCount(1, { timeout: 10000 });
 };
 
 test.describe('Otenkigurashi weather presentation', () => {
@@ -45,6 +48,26 @@ test.describe('Otenkigurashi weather presentation', () => {
         for (const weather of ['Clear', 'Clouds', 'Rain']) {
             await page.goto(route(weather, 'summer', 'tsuyu'), { waitUntil: 'domcontentloaded' });
             await expect(page.locator('[data-testid="tsuyu-atmosphere"]')).toHaveCount(1);
+        }
+    });
+
+    test('keeps first light and illegal events resolved in the route snapshot', async ({ page }) => {
+        await page.goto(route('Morning', 'winter', 'first_light'), { waitUntil: 'domcontentloaded' });
+        await expect(page.locator('main[data-world-weather="Morning"][data-world-season="winter"][data-world-season-event="first_light"]')).toHaveCount(1);
+        await expect(page.locator('[data-testid="first-light-atmosphere"]')).toHaveCount(1);
+
+        await page.goto(route('Snow', 'summer', 'tsuyu'), { waitUntil: 'domcontentloaded' });
+        await expect(page.locator('main[data-world-weather="Snow"][data-world-season="summer"][data-world-season-event="none"]')).toHaveCount(1);
+        await expect(page.locator('[data-testid="tsuyu-atmosphere"]')).toHaveCount(0);
+    });
+});
+
+test.describe('resolved world state across screens', () => {
+    test('keeps Morning first light consistent on home, card, and Denshouo', async ({ page }) => {
+        const query = 'lang=ja&weather=Morning&season=winter&seasonEvent=first_light';
+        for (const path of [`/?${query}`, `/card?${query}`, `/denshouo?${query}`]) {
+            await page.goto(path, { waitUntil: 'domcontentloaded' });
+            await expect(page.locator('main[data-world-weather="Morning"][data-world-season="winter"][data-world-season-event="first_light"]')).toHaveCount(1);
         }
     });
 });

--- a/src/app/card/page.tsx
+++ b/src/app/card/page.tsx
@@ -1,20 +1,44 @@
 import ClientInitializer from '@/components/ClientInitializer';
 import { fetchPlanetData } from '@/lib/actions';
-import type { WeatherType } from '@/store';
+import type { SeasonEventType, SeasonType, WeatherType } from '@/store';
+import { parseWorldStateRecord, resolveWorldState } from '@/lib/worldState';
 import CardScene from './CardScene';
 import WeatherEffectsOverlay from '@/components/dom/WeatherEffectsOverlay';
 
 export const dynamic = 'force-dynamic';
 
-export default async function CardPage() {
+type SearchParams = {
+    weather?: string | string[];
+    season?: string | string[];
+    seasonEvent?: string | string[];
+};
+
+export default async function CardPage({
+    searchParams,
+}: {
+    searchParams?: SearchParams | Promise<SearchParams>;
+}) {
     const data = await fetchPlanetData();
-    const weather = data.weather as WeatherType;
+    const routeState = parseWorldStateRecord((await searchParams) ?? {});
+    const resolvedState = resolveWorldState(routeState, {
+        weather: data.weather as WeatherType,
+        season: data.season as SeasonType,
+        seasonEvent: data.seasonEvent as SeasonEventType,
+    });
+    const weather = resolvedState.weather;
     const visualWeather = weather === 'Clear' ? 'Morning' : weather;
 
     return (
-        <main className="card-capture-page relative flex h-[400px] w-[800px] select-none items-center justify-center overflow-hidden rounded-xl border border-cyan-100/10 bg-[#050505] text-white shadow-2xl">
+        <main
+            data-world-weather={visualWeather}
+            data-world-season={resolvedState.season}
+            data-world-season-event={resolvedState.seasonEvent}
+            className="card-capture-page relative flex h-[400px] w-[800px] select-none items-center justify-center overflow-hidden rounded-xl border border-cyan-100/10 bg-[#050505] text-white shadow-2xl"
+        >
             <ClientInitializer
                 initialWeather={visualWeather}
+                initialSeason={resolvedState.season}
+                initialSeasonEvent={resolvedState.seasonEvent}
                 initialActivity={data.activityLevel}
             />
 
@@ -35,7 +59,7 @@ export default async function CardPage() {
 
             <div className="absolute bottom-5 left-6 z-30 font-mono text-xs tracking-[0.18em] text-cyan-100/70">
                 <p className="mb-1 text-sm font-bold tracking-[0.2em] text-white">WAKATO | LIVING PLANET</p>
-                <p>STATUS: ACTIVE // WEATHER: {data.weather.toUpperCase()}</p>
+                <p>STATUS: ACTIVE // WEATHER: {weather.toUpperCase()}</p>
             </div>
 
             <div className="absolute right-6 top-5 z-30 font-mono text-[10px] tracking-[0.24em] text-cyan-100/45">

--- a/src/app/denshouo/DenshouoClient.tsx
+++ b/src/app/denshouo/DenshouoClient.tsx
@@ -133,6 +133,9 @@ export default function DenshouoClient() {
         <>
         <FishCursor />
         <main
+            data-world-weather={displayedWeather}
+            data-world-season={displayedSeason}
+            data-world-season-event={displayedSeasonEvent}
             className="relative min-h-dvh bg-[radial-gradient(circle_at_top_left,rgba(56,189,248,0.10),transparent_28%),radial-gradient(circle_at_bottom,rgba(20,184,166,0.12),transparent_35%),#041116] text-white overflow-x-hidden"
             style={{ cursor: isFinePointer ? 'none' : 'auto' }}
         >

--- a/src/app/otenkigurashi/OtenkiGurashiClient.tsx
+++ b/src/app/otenkigurashi/OtenkiGurashiClient.tsx
@@ -2,6 +2,7 @@
 
 import {
     AUTUMN_BACKGROUND_GRADIENT,
+    FIRST_LIGHT_BACKGROUND_GRADIENT,
     SPRING_FLOWER_CLOUDY_BACKGROUND_GRADIENT,
     TSUYU_CLEAR_BACKGROUND_GRADIENT,
     TSUYU_CLOUDS_BACKGROUND_GRADIENT,
@@ -9,6 +10,7 @@ import {
     WINTER_BACKGROUND_GRADIENT,
 } from '@/lib/otenkigurashiSeasonal';
 import { useWorldState } from '@/components/WorldStateProvider';
+import { getWorldVisualProfile } from '@/lib/worldVisualProfile';
 import { OTENKI_COPY } from './otenkigurashiCopy';
 import WeatherCursor from './WeatherCursor';
 import { useOtenkiPageController } from './useOtenkiPageController';
@@ -52,6 +54,7 @@ export default function OtenkiGurashiClient() {
     const { lang, moonPhaseOverride, ...pageState } = controller;
     const { activeSection, heroRef, conceptRef, featuresRef, techRef, bottomRef, overrideDialog, showHeavyEffects, isFinePointer, handleInteract, handleTenchanClick, handleReturn } = pageState;
     const t = OTENKI_COPY[lang];
+    const visualProfile = getWorldVisualProfile(displayedWorldState);
     let bgGradient = "from-[#aee1f9] to-[#e0f4fc]"; // Default (Clear)
     if (displayedWeather === 'Clouds') {
         bgGradient = "from-[#6b7a8d] via-[#8fa0b0] to-[#b5c2ca]";
@@ -65,23 +68,27 @@ export default function OtenkiGurashiClient() {
         bgGradient = "from-[#030915] via-[#071428] to-[#0b1f36]";
     }
 
-    if (displayedSeason === 'spring' && (displayedWeather === 'Clear' || displayedWeather === 'Morning')) {
+    if (visualProfile.showSpring) {
         bgGradient = "from-[#fcedf3] via-[#fff5f9] to-[#fffdfd]";
     }
 
-    if (displayedSeason === 'spring' && displayedWeather === 'Clouds') {
+    if (visualProfile.showFlowerCloudy) {
         bgGradient = "from-[#c5d1d9] via-[#e6e9e7] to-[#f3e8ed]";
     }
 
-    if (displayedSeason === 'autumn' && (displayedWeather === 'Clear' || displayedWeather === 'Morning')) {
+    if (visualProfile.showAutumn) {
         bgGradient = "from-[#c7ded9] via-[#f1e6ce] to-[#e4b36f]";
     }
 
-    if (displayedSeason === 'summer' && displayedSeasonEvent === 'geshi' && (displayedWeather === 'Clear' || displayedWeather === 'Morning')) {
+    if (visualProfile.showGeshi) {
         bgGradient = "from-[#bddfeb] via-[#e0eef0] to-[#fff0cf]";
     }
 
-    if (displayedSeasonEvent === 'tsuyu') {
+    if (visualProfile.showFirstLight) {
+        bgGradient = FIRST_LIGHT_BACKGROUND_GRADIENT;
+    }
+
+    if (visualProfile.showTsuyu) {
         bgGradient = displayedWeather === 'Rain'
             ? TSUYU_RAIN_BACKGROUND_GRADIENT
             : displayedWeather === 'Clouds'
@@ -94,19 +101,26 @@ export default function OtenkiGurashiClient() {
     const springCardStyle = displayedSeason === 'spring' && (displayedWeather === 'Clear' || displayedWeather === 'Morning')
         ? 'border-white shadow-[0_20px_60px_-15px_rgba(152,173,194,0.3)]'
         : 'border-white shadow-[0_20px_60px_-15px_rgba(152,173,194,0.3)]';
-    const isSpringSun = displayedSeason === 'spring' && (displayedWeather === 'Clear' || displayedWeather === 'Morning');
-    const isFlowerCloudy = displayedSeason === 'spring' && displayedWeather === 'Clouds';
-    const isGeshiSun = displayedSeason === 'summer' && displayedSeasonEvent === 'geshi' && (displayedWeather === 'Clear' || displayedWeather === 'Morning');
-    const isTsuyu = displayedSeason === 'summer' && displayedSeasonEvent === 'tsuyu';
-    const isWinterSnowScene = displayedSeason === 'winter' && displayedWeather === 'Snow';
+    const isSpringSun = visualProfile.showSpring;
+    const isFlowerCloudy = visualProfile.showFlowerCloudy;
+    const isGeshiSun = visualProfile.showGeshi;
+    const isTsuyu = visualProfile.showTsuyu;
+    const isFirstLight = visualProfile.showFirstLight;
+    const isWinterSnowScene = visualProfile.showWinterSnow;
 
     return (
         <>
             <WeatherCursor weatherOverride={displayedWeather} seasonOverride={displayedSeason} />
-            <main className={`relative w-full min-h-[120dvh] ${displayedWeather !== 'Rain' && displayedWeather !== 'Snow' ? 'bg-gradient-to-b' : ''} ${bgGradient} ${displayedWeather === 'Thunder' || displayedWeather === 'Night' ? 'text-gray-200' : 'text-gray-700'} overflow-hidden font-sans pb-32 transition-colors duration-1000`} style={{
+            <main
+                data-world-weather={displayedWeather}
+                data-world-season={displayedSeason}
+                data-world-season-event={displayedSeasonEvent}
+                className={`relative w-full min-h-[120dvh] ${displayedWeather !== 'Rain' && displayedWeather !== 'Snow' ? 'bg-gradient-to-b' : ''} ${bgGradient} ${displayedWeather === 'Thunder' || displayedWeather === 'Night' ? 'text-gray-200' : 'text-gray-700'} overflow-hidden font-sans pb-32 transition-colors duration-1000`} style={{
                 cursor: isFinePointer ? 'none' : 'auto',
                 background: displayedSeason === 'autumn' && (displayedWeather === 'Clear' || displayedWeather === 'Morning')
                     ? AUTUMN_BACKGROUND_GRADIENT
+                    : isFirstLight
+                        ? FIRST_LIGHT_BACKGROUND_GRADIENT
                     : isTsuyu && (displayedWeather === 'Clear' || displayedWeather === 'Morning')
                         ? TSUYU_CLEAR_BACKGROUND_GRADIENT
                     : isTsuyu && displayedWeather === 'Clouds'
@@ -287,10 +301,14 @@ export default function OtenkiGurashiClient() {
                                         : 'radial-gradient(circle at 35% 35%, rgba(255,245,180,0.96) 0%, rgba(255,213,112,0.92) 38%, rgba(255,170,58,0.92) 100%)',
                                     boxShadow: isSpringSun
                                         ? '0 0 45px rgba(247,190,101,0.28), 0 0 110px rgba(236,163,80,0.12)'
+                                        : isFirstLight
+                                            ? '0 0 50px rgba(255,184,108,0.42), 0 0 118px rgba(219,123,91,0.16)'
                                         : isGeshiSun
                                             ? '0 0 28px rgba(150,211,240,0.22), 0 0 72px rgba(124,190,226,0.09)'
                                         : '0 0 45px rgba(255,205,110,0.55), 0 0 110px rgba(255,187,82,0.35)',
-                                    animation: isGeshiSun
+                                    animation: isFirstLight
+                                        ? 'first-light-sun-soft-pulse 5.4s ease-in-out infinite'
+                                    : isGeshiSun
                                         ? 'geshi-sun-soft-pulse 4.6s ease-in-out infinite'
                                         : 'sun-soft-pulse 4.6s ease-in-out infinite',
                                 }}
@@ -300,6 +318,8 @@ export default function OtenkiGurashiClient() {
                                 style={{
                                     background: isSpringSun
                                         ? 'radial-gradient(circle, rgba(255,224,157,0.20) 0%, rgba(245,183,97,0.06) 42%, rgba(245,183,97,0.0) 74%)'
+                                        : isFirstLight
+                                            ? 'radial-gradient(circle, rgba(255,207,145,0.28) 0%, rgba(234,151,113,0.09) 42%, rgba(234,151,113,0.0) 74%)'
                                         : isGeshiSun
                                             ? 'radial-gradient(circle, rgba(185,228,246,0.13) 0%, rgba(145,207,235,0.035) 42%, rgba(145,207,235,0.0) 74%)'
                                         : 'radial-gradient(circle, rgba(255,220,150,0.36) 0%, rgba(255,220,150,0.08) 42%, rgba(255,220,150,0.0) 74%)',
@@ -315,6 +335,10 @@ export default function OtenkiGurashiClient() {
                         @keyframes geshi-sun-soft-pulse {
                             0%, 100% { transform: scale(1); opacity: 0.84; }
                             50% { transform: scale(1.035); opacity: 0.9; }
+                        }
+                        @keyframes first-light-sun-soft-pulse {
+                            0%, 100% { transform: scale(1); opacity: 0.96; }
+                            50% { transform: scale(1.08); opacity: 1; }
                         }
                         @keyframes sun-aura-spin {
                             from { transform: rotate(0deg); }
@@ -388,8 +412,8 @@ export default function OtenkiGurashiClient() {
                         section={activeSection}
                         weather={displayedWeather}
                         showUmbrella={false}
-                        showSakura={isSpringSun || isFlowerCloudy}
-                        showMomiji={displayedSeason === 'autumn' && (displayedWeather === 'Clear' || displayedWeather === 'Morning')}
+                        showSakura={visualProfile.showSpring || visualProfile.showFlowerCloudy}
+                        showMomiji={visualProfile.showAutumn}
                         showHydrangea={isTsuyu}
                         showSnowflake={displayedWeather === 'Snow'}
                         showRainDrop={displayedWeather === 'Rain' && !isTsuyu}

--- a/src/app/otenkigurashi/OtenkiSeasonEffects.tsx
+++ b/src/app/otenkigurashi/OtenkiSeasonEffects.tsx
@@ -5,15 +5,12 @@ import {
     AUTUMN_LEAF_SPECS,
     autumnLeafStyle,
     FLOWER_CLOUDY_PETAL_SPECS,
+    FIRST_LIGHT_ATMOSPHERE_GRADIENT,
+    SPRING_PETAL_SPECS,
     TSUYU_ATMOSPHERE_GRADIENT,
 } from '@/lib/otenkigurashiSeasonal';
 import { getWorldVisualProfile } from '@/lib/worldVisualProfile';
 import { useMemo } from 'react';
-
-const seasonalValue = (index: number, salt: number) => {
-    const value = Math.sin(index * 12.9898 + salt * 78.233) * 43758.5453123;
-    return value - Math.floor(value);
-};
 
 export default function OtenkiSeasonEffects({
     season,
@@ -26,6 +23,7 @@ export default function OtenkiSeasonEffects({
 }) {
     const {
         showTsuyu,
+        showFirstLight,
         showSpring,
         showFlowerCloudy,
         showGeshi,
@@ -34,20 +32,8 @@ export default function OtenkiSeasonEffects({
         showWinterSnow,
     } = getWorldVisualProfile({ weather, season, seasonEvent });
     const showWinter = showWinterSnow;
-    const springPetals = useMemo(
-        () => Array.from({ length: 24 }, (_, index) => ({
-            left: seasonalValue(index, 1) * 100,
-            // Keep a few petals on screen soon after the page opens while
-            // preserving enough spread for a gentle, continuous fall.
-            delay: seasonalValue(index, 2) * 4,
-            duration: 12 + seasonalValue(index, 3) * 7,
-            size: 7 + seasonalValue(index, 4) * 8,
-            drift: -48 + seasonalValue(index, 5) * 96,
-            rotate: seasonalValue(index, 6) * 360,
-        })),
-        []
-    );
-    if (!showTsuyu && !showSpring && !showFlowerCloudy && !showSummer && !showGeshi && !showAutumn && !showWinter) return null;
+    const springPetals = useMemo(() => SPRING_PETAL_SPECS, []);
+    if (!showTsuyu && !showFirstLight && !showSpring && !showFlowerCloudy && !showSummer && !showGeshi && !showAutumn && !showWinter) return null;
 
     return (
         <div className="fixed inset-0 pointer-events-none z-10 overflow-hidden" aria-hidden="true">
@@ -61,6 +47,8 @@ export default function OtenkiSeasonEffects({
             {showSpring && <div className="absolute inset-0 otenki-season-spring" />}
 
             {showFlowerCloudy && <div className="absolute inset-0 otenki-season-flower-cloudy" />}
+
+            {showFirstLight && <div data-testid="first-light-atmosphere" className="absolute inset-0 otenki-season-first-light" />}
 
             {showSpring && springPetals.map((petal, index) => (
                 <span
@@ -173,6 +161,11 @@ export default function OtenkiSeasonEffects({
                     animation: otenki-flower-cloudy-haze 12s ease-in-out infinite alternate;
                 }
 
+                .otenki-season-first-light {
+                    background: ${FIRST_LIGHT_ATMOSPHERE_GRADIENT};
+                    animation: otenki-first-light-air 9s ease-in-out infinite alternate;
+                }
+
                 .otenki-season-summer {
                     background:
                         radial-gradient(ellipse at 84% 8%, rgba(255,220,108,0.62) 0%, rgba(255,192,69,0.24) 28%, transparent 54%),
@@ -252,6 +245,11 @@ export default function OtenkiSeasonEffects({
                 @keyframes otenki-flower-cloudy-haze {
                     from { transform: translate3d(-0.6%, 0, 0) scale(1.02); opacity: 0.66; }
                     to { transform: translate3d(0.6%, 0.5%, 0) scale(1.04); opacity: 0.86; }
+                }
+
+                @keyframes otenki-first-light-air {
+                    from { transform: translate3d(-0.4%, 0, 0) scale(1.02); opacity: 0.56; }
+                    to { transform: translate3d(0.4%, 0.4%, 0) scale(1.04); opacity: 0.78; }
                 }
 
                 @keyframes otenki-sakura-fall {

--- a/src/app/otenkigurashi/WeatherCursor.tsx
+++ b/src/app/otenkigurashi/WeatherCursor.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from 'react';
 import type { SeasonType, WeatherType } from '@/store';
 import { useWorldState } from '@/components/WorldStateProvider';
+import { getWorldVisualProfile } from '@/lib/worldVisualProfile';
 
 export default function WeatherCursor({ weatherOverride, seasonOverride }: { weatherOverride?: WeatherType; seasonOverride?: SeasonType } = {}) {
     const worldState = useWorldState();
@@ -10,8 +11,10 @@ export default function WeatherCursor({ weatherOverride, seasonOverride }: { wea
     const season = seasonOverride ?? worldState.season;
     const weatherRef = useRef(weather);
     const seasonRef = useRef(season);
+    const seasonEventRef = useRef(worldState.seasonEvent);
     useEffect(() => { weatherRef.current = weather; }, [weather]);
     useEffect(() => { seasonRef.current = season; }, [season]);
+    useEffect(() => { seasonEventRef.current = worldState.seasonEvent; }, [worldState.seasonEvent]);
 
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const stateRef = useRef({
@@ -23,8 +26,6 @@ export default function WeatherCursor({ weatherOverride, seasonOverride }: { wea
         sunRot: 0,
         // Spring / Clear
         sakuraRot: 0,
-        // Autumn / Clear
-        momijiRot: 0,
         // Snow
         snowRot: 0,
         // Rain
@@ -195,64 +196,42 @@ export default function WeatherCursor({ weatherOverride, seasonOverride }: { wea
             ctx.restore();
         };
 
-        //  MOMIJI — maple leaf with a warm amber palette for the autumn cursor
-        const drawMomiji = (t: number, momijiRot: number) => {
-            const pulse = 1 + Math.sin(t * 2.1) * 0.04;
+        //  MOMIJI — same fixed hair ornament shape as TenchanCompanion
+        const drawMomiji = () => {
             ctx.save();
-            ctx.rotate(momijiRot);
-            ctx.scale(pulse, pulse);
-            ctx.shadowBlur = 7;
-            ctx.shadowColor = 'rgba(188,112,45,0.28)';
+            ctx.rotate(12 * Math.PI / 180);
+            ctx.scale(0.78, 0.78);
 
             ctx.beginPath();
-            ctx.moveTo(0, -14);
-            ctx.quadraticCurveTo(1.4, -10.5, 2.8, -7.4);
-            ctx.quadraticCurveTo(5.8, -9.3, 8.5, -10.4);
-            ctx.quadraticCurveTo(7.6, -6.9, 6.4, -4.1);
-            ctx.quadraticCurveTo(10.5, -3.1, 13.8, -1.4);
-            ctx.quadraticCurveTo(10.1, 0.2, 6.8, 1.2);
-            ctx.quadraticCurveTo(8, 5.4, 8.8, 8.3);
-            ctx.quadraticCurveTo(4.2, 6.7, 1.8, 4.7);
-            ctx.quadraticCurveTo(1, 9, 1.2, 12.8);
-            ctx.quadraticCurveTo(0.3, 13.8, 0, 14.5);
-            ctx.quadraticCurveTo(-0.3, 13.8, -1.2, 12.8);
-            ctx.quadraticCurveTo(-1, 9, -1.8, 4.7);
-            ctx.quadraticCurveTo(-4.2, 6.7, -8.8, 8.3);
-            ctx.quadraticCurveTo(-8, 5.4, -6.8, 1.2);
-            ctx.quadraticCurveTo(-10.1, 0.2, -13.8, -1.4);
-            ctx.quadraticCurveTo(-10.5, -3.1, -6.4, -4.1);
-            ctx.quadraticCurveTo(-7.6, -6.9, -8.5, -10.4);
-            ctx.quadraticCurveTo(-5.8, -9.3, -2.8, -7.4);
-            ctx.quadraticCurveTo(-1.4, -10.5, 0, -14);
+            ctx.moveTo(0, 14);
+            ctx.bezierCurveTo(-1, 10, -1, 6, -1, 3);
+            ctx.bezierCurveTo(-5, 6, -10, 8, -14, 7);
+            ctx.bezierCurveTo(-12, 4, -9, 1, -6, -1);
+            ctx.bezierCurveTo(-10, -1, -13, -3, -14, -5);
+            ctx.bezierCurveTo(-11, -7, -7, -8, -4, -7);
+            ctx.bezierCurveTo(-4, -11, -2, -14, 0, -16);
+            ctx.bezierCurveTo(2, -14, 4, -11, 4, -7);
+            ctx.bezierCurveTo(7, -8, 11, -7, 14, -5);
+            ctx.bezierCurveTo(13, -3, 10, -1, 6, -1);
+            ctx.bezierCurveTo(9, 1, 12, 4, 14, 7);
+            ctx.bezierCurveTo(10, 8, 5, 6, 1, 3);
+            ctx.bezierCurveTo(1, 6, 1, 10, 0, 14);
             ctx.closePath();
-            const leaf = ctx.createLinearGradient(-8, -12, 8, 12);
-            leaf.addColorStop(0, '#ffd76f');
-            leaf.addColorStop(0.55, '#efa94d');
-            leaf.addColorStop(1, '#d8783e');
-            ctx.fillStyle = leaf;
+            ctx.fillStyle = '#e6a14d';
             ctx.fill();
-            ctx.strokeStyle = 'rgba(173,91,39,0.68)';
-            ctx.lineWidth = 0.9;
+            ctx.strokeStyle = '#b86f32';
+            ctx.lineWidth = 1.2;
+            ctx.lineJoin = 'round';
             ctx.stroke();
 
-            ctx.shadowBlur = 0;
-            ctx.strokeStyle = 'rgba(255,224,137,0.76)';
-            ctx.lineWidth = 0.9;
+            ctx.strokeStyle = '#f7d27d';
+            ctx.lineWidth = 1.2;
             ctx.lineCap = 'round';
             ctx.beginPath();
-            ctx.moveTo(0, 11); ctx.lineTo(0, -7);
-            ctx.moveTo(0, 0); ctx.lineTo(-6, -4.5);
-            ctx.moveTo(0, 0); ctx.lineTo(6, -4.5);
+            ctx.moveTo(0, 11); ctx.lineTo(0, -9);
+            ctx.moveTo(0, 1); ctx.lineTo(-6, -2);
+            ctx.moveTo(0, 1); ctx.lineTo(6, -2);
             ctx.stroke();
-
-            const drift = Math.sin(t * 1.7) * 1.6;
-            ctx.fillStyle = 'rgba(233,153,69,0.78)';
-            ctx.beginPath();
-            ctx.moveTo(-17 + drift, -8); ctx.lineTo(-14 + drift, -12); ctx.lineTo(-11 + drift, -8); ctx.lineTo(-14 + drift, -4); ctx.closePath();
-            ctx.fill();
-            ctx.beginPath();
-            ctx.moveTo(15 - drift, 8); ctx.lineTo(18 - drift, 4); ctx.lineTo(21 - drift, 8); ctx.lineTo(18 - drift, 12); ctx.closePath();
-            ctx.fill();
             ctx.restore();
         };
 
@@ -555,9 +534,13 @@ export default function WeatherCursor({ weatherOverride, seasonOverride }: { wea
             const speed = Math.hypot(s.vx, s.vy);
 
             // ── per-weather state update ────────────────────────────────────
-            const isClearOrMorning = w === 'Clear' || w === 'Morning';
-            const isSpringClear = seasonRef.current === 'spring' && isClearOrMorning;
-            const isAutumnClear = seasonRef.current === 'autumn' && isClearOrMorning;
+            const visualProfile = getWorldVisualProfile({
+                weather: w,
+                season: seasonRef.current,
+                seasonEvent: seasonEventRef.current,
+            });
+            const isSpringClear = visualProfile.showSpring;
+            const isAutumnClear = visualProfile.showAutumn;
             if (w === 'Clouds') {
                 s.bobPhase += 0.038 * dt;
                 const tSqX = 1 + Math.min(speed * 0.013, 0.22);
@@ -568,7 +551,6 @@ export default function WeatherCursor({ weatherOverride, seasonOverride }: { wea
             } else if (w === 'Clear' || w === 'Morning') {
                 s.sunRot += 0.018 * dt;
                 if (isSpringClear) s.sakuraRot += 0.012 * dt;
-                if (isAutumnClear) s.momijiRot += 0.009 * dt;
             } else if (w === 'Snow') {
                 s.snowRot += 0.012 * dt;
             } else if (w === 'Rain') {
@@ -622,7 +604,7 @@ export default function WeatherCursor({ weatherOverride, seasonOverride }: { wea
                 if (isSpringClear) {
                     drawSakura(t, s.sakuraRot);
                 } else if (isAutumnClear) {
-                    drawMomiji(t, s.momijiRot);
+                    drawMomiji();
                 } else {
                     drawSun(t, s.sunRot);
                 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -119,8 +119,11 @@ export default async function Home({
 
   const works = t.works.map((work) => ({ ...work }));
 
-  return (
+    return (
     <main
+      data-world-weather={initialWeather}
+      data-world-season={initialSeason}
+      data-world-season-event={initialSeasonEvent}
       className="relative w-full min-h-[100dvh] text-white font-sans bg-[#050505]"
       style={{ userSelect: 'none', WebkitUserSelect: 'none', WebkitTouchCallout: 'none' }}
     >

--- a/src/components/GlobalTransitionOverlay.tsx
+++ b/src/components/GlobalTransitionOverlay.tsx
@@ -9,6 +9,9 @@ import {
     AUTUMN_LEAF_SPECS,
     autumnLeafStyle,
     FLOWER_CLOUDY_PETAL_SPECS,
+    FIRST_LIGHT_ATMOSPHERE_GRADIENT,
+    FIRST_LIGHT_BACKGROUND_GRADIENT,
+    SPRING_PETAL_SPECS,
     SPRING_FLOWER_CLOUDY_BACKGROUND_GRADIENT,
     TSUYU_ATMOSPHERE_GRADIENT,
 } from '@/lib/otenkigurashiSeasonal';
@@ -28,32 +31,18 @@ const WaveTransitionCanvas = dynamic(() => import('@/components/canvas/WaveTrans
 const MoonriseTransitionCanvas = dynamic(() => import('@/components/canvas/MoonriseTransitionCanvas'), { ssr: false });
 const CaptchaLockTransitionCanvas = dynamic(() => import('@/components/canvas/CaptchaLockTransitionCanvas'), { ssr: false });
 
-const seasonalValue = (index: number, salt: number) => {
-    const value = Math.sin(index * 12.9898 + salt * 78.233) * 43758.5453123;
-    return value - Math.floor(value);
-};
-
 function SeasonalTransitionAtmosphere({ season, seasonEvent, weather }: { season: SeasonType; seasonEvent: SeasonEventType; weather: WeatherType }) {
     const {
         isClear,
         isGeshiEvent,
+        showFirstLight,
         showSpring,
         showFlowerCloudy,
         showAutumn,
         showWinterSnow,
         showTsuyu,
     } = getWorldVisualProfile({ weather, season, seasonEvent });
-    const springPetals = useMemo(
-        () => Array.from({ length: 18 }, (_, index) => ({
-            left: seasonalValue(index, 21) * 100,
-            delay: seasonalValue(index, 22) * 1.8,
-            duration: 5.5 + seasonalValue(index, 23) * 3.5,
-            size: 7 + seasonalValue(index, 24) * 7,
-            drift: -42 + seasonalValue(index, 25) * 84,
-            rotate: seasonalValue(index, 26) * 360,
-        })),
-        []
-    );
+    const springPetals = useMemo(() => SPRING_PETAL_SPECS, []);
     if (season === 'none') return null;
 
     const isGeshi = isGeshiEvent;
@@ -73,6 +62,8 @@ function SeasonalTransitionAtmosphere({ season, seasonEvent, weather }: { season
         autumn: showAutumn ? AUTUMN_BACKGROUND_GRADIENT : 'transparent',
         winter: showWinterSnow
             ? 'linear-gradient(110deg, rgba(193,228,249,0.28), transparent 34%, transparent 68%, rgba(175,215,242,0.24)), radial-gradient(ellipse at 50% 100%, rgba(255,255,255,0.34), transparent 65%)'
+            : showFirstLight
+                ? FIRST_LIGHT_BACKGROUND_GRADIENT
             : 'transparent',
     };
 
@@ -81,7 +72,11 @@ function SeasonalTransitionAtmosphere({ season, seasonEvent, weather }: { season
             key={`season-atmosphere-${season}-${seasonEvent}`}
             className="fixed inset-0 z-[10000] pointer-events-none overflow-hidden"
             style={{
-                background: showTsuyu ? TSUYU_ATMOSPHERE_GRADIENT : backgroundBySeason[season],
+                background: showTsuyu
+                    ? TSUYU_ATMOSPHERE_GRADIENT
+                    : showFirstLight
+                        ? FIRST_LIGHT_ATMOSPHERE_GRADIENT
+                        : backgroundBySeason[season],
                 mixBlendMode: 'normal',
                 boxShadow: showWinterSnow ? 'inset 0 0 80px rgba(199,230,249,0.36)' : undefined,
             }}
@@ -89,6 +84,8 @@ function SeasonalTransitionAtmosphere({ season, seasonEvent, weather }: { season
             animate={{
                 opacity: showTsuyu
                     ? [0.12, 0.24, 0.16]
+                    : showFirstLight
+                        ? [0.16, 0.30, 0.22]
                     : showAutumn
                     ? [0.34, 0.58, 0.44]
                     : showFlowerCloudy
@@ -131,14 +128,14 @@ function SeasonalTransitionAtmosphere({ season, seasonEvent, weather }: { season
                     className="absolute rounded-[70%_30%_70%_30%]"
                     style={{
                         left: `${petal.left}%`,
-                        top: '-6%',
+                        top: '-8%',
                         width: petal.size,
                         height: petal.size * 0.62,
                         background: 'linear-gradient(135deg, rgba(255,249,252,0.94), rgba(244,153,191,0.76))',
                         boxShadow: '0 0 8px rgba(255,180,211,0.34)',
                         transform: `rotate(${petal.rotate}deg)`,
                         opacity: 0.74,
-                        animation: `otenki-transition-sakura-fall ${petal.duration}s linear ${petal.delay}s infinite`,
+                        animation: `otenki-transition-sakura-fall ${petal.duration}s linear ${-petal.delay}s infinite`,
                         ['--transition-sakura-drift' as string]: `${petal.drift}px`,
                     }}
                 />
@@ -156,7 +153,7 @@ function SeasonalTransitionAtmosphere({ season, seasonEvent, weather }: { season
                         boxShadow: '0 0 6px rgba(248,193,214,0.16)',
                         transform: `rotate(${petal.rotate}deg)`,
                         opacity: 0.38,
-                        animation: `otenki-transition-sakura-fall ${petal.duration}s linear ${petal.delay}s infinite`,
+                        animation: `otenki-transition-sakura-fall ${petal.duration}s linear ${-petal.delay}s infinite`,
                         ['--transition-sakura-drift' as string]: `${petal.drift}px`,
                     }}
                 />

--- a/src/components/WorldStateProvider.tsx
+++ b/src/components/WorldStateProvider.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useStore } from '@/store';
-import { parseWorldStateParams, resolveWorldState } from '@/lib/worldState';
+import { canonicalizeWorldStateQuery, parseWorldStateParams, resolveWorldState } from '@/lib/worldState';
 import type { WorldState } from '@/lib/worldStateTypes';
 import { resolveSeasonState } from '@/lib/seasonResolver';
 
@@ -12,6 +12,8 @@ const WorldStateContext = createContext<WorldState | null>(null);
 export default function WorldStateProvider({ children }: { children: ReactNode }) {
     const searchParams = useSearchParams();
     const searchParamsKey = searchParams.toString();
+    const pathname = usePathname();
+    const router = useRouter();
     const storeWeather = useStore((state) => state.weather);
     const storeSeason = useStore((state) => state.season);
     const storeSeasonEvent = useStore((state) => state.seasonEvent);
@@ -56,6 +58,20 @@ export default function WorldStateProvider({ children }: { children: ReactNode }
             setWorldState(nextWorldState);
         }
     }, [routeWorldState.season, routeWorldState.seasonEvent, routeWorldState.weather, setWorldState]);
+
+    useEffect(() => {
+        const currentParams = new URLSearchParams(searchParamsKey);
+        const hasRouteWorldState = ['weather', 'season', 'seasonEvent'].some((key) => currentParams.has(key));
+        if (!hasRouteWorldState) return;
+
+        const canonicalQuery = canonicalizeWorldStateQuery(
+            currentParams,
+            worldState,
+        ).toString();
+        if (canonicalQuery !== searchParamsKey) {
+            router.replace(`${pathname}?${canonicalQuery}`, { scroll: false });
+        }
+    }, [pathname, router, searchParamsKey, worldState]);
 
     return (
         <WorldStateContext.Provider value={worldState}>

--- a/src/components/canvas/AbstractCore.tsx
+++ b/src/components/canvas/AbstractCore.tsx
@@ -4,6 +4,7 @@ import { useRef } from 'react';
 import { useThree } from '@react-three/fiber';
 import * as THREE from 'three';
 import { useStore } from '@/store';
+import { useWorldState } from '@/components/WorldStateProvider';
 import { useCoreInteraction } from './abstractCore/useCoreInteraction';
 import { useCoreParticles } from './abstractCore/useCoreParticles';
 import { useCoreAnimation } from './abstractCore/useCoreAnimation';
@@ -26,9 +27,11 @@ export default function AbstractCore({
     const wireframe2Ref = useRef<THREE.Mesh>(null);
 
     const isMobile = size.width < 768;
-    const { githubActivityLevel: storeActivityLevel, season, seasonEvent, weather: storeWeather } = useStore();
+    const storeActivityLevel = useStore((state) => state.githubActivityLevel);
+    const worldState = useWorldState();
     const githubActivityLevel = activityOverride ?? storeActivityLevel;
-    const weather = weatherOverride ?? storeWeather;
+    const weather = weatherOverride ?? worldState.weather;
+    const { season, seasonEvent } = worldState;
     const visual = getCoreVisualProfile(weather, season, seasonEvent);
     const initialColor = visual.baseColor;
     const initialInnerColor = visual.hoverColor;

--- a/src/components/canvas/SunburstTransitionCanvas.tsx
+++ b/src/components/canvas/SunburstTransitionCanvas.tsx
@@ -1,7 +1,11 @@
 'use client'
 
 import { motion } from 'framer-motion';
-import { AUTUMN_BACKGROUND_GRADIENT, TSUYU_CLEAR_BACKGROUND_GRADIENT } from '@/lib/otenkigurashiSeasonal';
+import {
+    AUTUMN_BACKGROUND_GRADIENT,
+    FIRST_LIGHT_BACKGROUND_GRADIENT,
+    TSUYU_CLEAR_BACKGROUND_GRADIENT,
+} from '@/lib/otenkigurashiSeasonal';
 import { getWorldVisualProfile } from '@/lib/worldVisualProfile';
 import type { WorldState } from '@/lib/worldState';
 
@@ -13,13 +17,17 @@ export default function SunburstTransitionCanvas({ worldState }: { worldState: W
     const isAutumnSun = profile.showAutumn;
     const isGeshiSun = profile.showGeshi;
     const isTsuyuSun = profile.showTsuyu;
+    const isFirstLightSun = profile.showFirstLight;
     const isCoolSun = isGeshiSun || isTsuyuSun;
+    const transitionDuration = isFirstLightSun ? 1.2 : 0.9;
     const background = isSpringSun
         ? 'linear-gradient(180deg, #f6e8ee 0%, #fdf3f7 42%, #fffafc 74%, #ffffff 100%)'
         : isAutumnSun
             ? AUTUMN_BACKGROUND_GRADIENT
         : isTsuyuSun
             ? TSUYU_CLEAR_BACKGROUND_GRADIENT
+        : isFirstLightSun
+            ? FIRST_LIGHT_BACKGROUND_GRADIENT
         : isGeshiSun
             ? 'linear-gradient(180deg, #a9d6e8 0%, #cfe8ee 42%, #e8f0e8 74%, #f7edcf 100%)'
         : 'linear-gradient(180deg, #82cbf6 0%, #dff2ff 42%, #fff3d8 74%, #ffefcf 100%)';
@@ -33,7 +41,9 @@ export default function SunburstTransitionCanvas({ worldState }: { worldState: W
             <motion.div
                 className="absolute inset-0 pointer-events-none"
                 style={{
-                    background: isCoolSun
+                    background: isFirstLightSun
+                        ? 'radial-gradient(ellipse 100% 72% at 76% 18%, rgba(255,202,154,0.20) 0%, rgba(232,151,116,0.08) 44%, rgba(232,151,116,0) 78%)'
+                        : isCoolSun
                         ? isTsuyuSun
                             ? 'radial-gradient(ellipse 100% 72% at 76% 18%, rgba(191,222,239,0.16) 0%, rgba(164,195,220,0.06) 44%, rgba(164,195,220,0) 78%)'
                             : 'radial-gradient(ellipse 100% 72% at 76% 18%, rgba(190,229,246,0.14) 0%, rgba(164,215,237,0.06) 44%, rgba(164,215,237,0) 78%)'
@@ -41,7 +51,7 @@ export default function SunburstTransitionCanvas({ worldState }: { worldState: W
                 }}
                 initial={{ opacity: 0 }}
                 animate={{ opacity: [0.08, 0.24, 0.18] }}
-                transition={{ duration: 0.9, ease: [0.22, 1, 0.36, 1] }}
+                transition={{ duration: transitionDuration, ease: [0.22, 1, 0.36, 1] }}
             />
 
             {/* 遷移後の晴れ画面と同じ太陽 */}
@@ -50,6 +60,8 @@ export default function SunburstTransitionCanvas({ worldState }: { worldState: W
                 style={{
                     background: isSpringSun
                         ? 'radial-gradient(circle at 35% 35%, rgba(255,248,214,0.98) 0%, rgba(255,218,133,0.92) 38%, rgba(242,176,76,0.88) 100%)'
+                    : isFirstLightSun
+                        ? 'radial-gradient(circle at 35% 35%, rgba(255,248,211,0.97) 0%, rgba(255,220,133,0.92) 38%, rgba(246,181,70,0.86) 100%)'
                     : isCoolSun
                         ? 'radial-gradient(circle at 35% 35%, rgba(255,248,211,0.96) 0%, rgba(255,220,133,0.90) 38%, rgba(246,181,70,0.84) 100%)'
                         : 'radial-gradient(circle at 35% 35%, rgba(255,245,180,0.96) 0%, rgba(255,213,112,0.92) 38%, rgba(255,170,58,0.92) 100%)',

--- a/src/components/canvas/Weather.tsx
+++ b/src/components/canvas/Weather.tsx
@@ -3,7 +3,8 @@
 import { useRef, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
-import { useStore, type WeatherType } from '@/store';
+import { type WeatherType } from '@/store';
+import { useWorldState } from '@/components/WorldStateProvider';
 
 const seededRandom = (index: number, salt: number) => {
     const x = Math.sin(index * 12.9898 + salt * 78.233) * 43758.5453;
@@ -192,8 +193,8 @@ void main() {
 `;
 
 export default function Weather({ weatherOverride }: { weatherOverride?: WeatherType } = {}) {
-    const { weather: storeWeather } = useStore();
-    const weather = weatherOverride ?? storeWeather;
+    const worldState = useWorldState();
+    const weather = weatherOverride ?? worldState.weather;
 
     const linesRef = useRef<THREE.LineSegments>(null);
 

--- a/src/components/canvas/abstractCore/coreVisuals.test.ts
+++ b/src/components/canvas/abstractCore/coreVisuals.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { getCoreVisualProfile } from './coreVisuals';
+
+describe('getCoreVisualProfile', () => {
+    it('keeps first light as a winter Morning-only visual profile', () => {
+        const firstLight = getCoreVisualProfile('Morning', 'winter', 'first_light');
+        const snow = getCoreVisualProfile('Snow', 'winter', 'first_light');
+
+        expect(firstLight.baseColor).toBe('#e9a568');
+        expect(snow.baseColor).toBe('#c9eeff');
+    });
+
+    it('uses the same seasonal profile for Morning as for the corresponding clear scene', () => {
+        expect(getCoreVisualProfile('Morning', 'spring')).toEqual(getCoreVisualProfile('Clear', 'spring'));
+        expect(getCoreVisualProfile('Morning', 'summer')).toEqual(getCoreVisualProfile('Clear', 'summer'));
+        expect(getCoreVisualProfile('Morning', 'autumn')).toEqual(getCoreVisualProfile('Clear', 'autumn'));
+    });
+});

--- a/src/components/canvas/abstractCore/coreVisuals.ts
+++ b/src/components/canvas/abstractCore/coreVisuals.ts
@@ -160,6 +160,18 @@ const WINTER_SNOW_VISUAL: CoreVisualProfile = {
     particleSize: 0.027,
 };
 
+const FIRST_LIGHT_VISUAL: CoreVisualProfile = {
+    ...CORE_VISUALS.Morning,
+    baseColor: '#e9a568',
+    hoverColor: '#ffd19a',
+    activeColor: '#fff0c9',
+    meshOpacity: 0.18,
+    wireOpacity: 0.14,
+    innerOpacity: 0.07,
+    ringPulse: 0.48,
+    particleSize: 0.03,
+};
+
 export const getCoreVisualProfile = (
     weather: WeatherType,
     season: SeasonType,
@@ -167,19 +179,23 @@ export const getCoreVisualProfile = (
 ): CoreVisualProfile => {
     const defaultVisual = CORE_VISUALS[weather] ?? CORE_VISUALS.Clear;
 
+    if (season === 'winter' && seasonEvent === 'first_light' && weather === 'Morning') {
+        return FIRST_LIGHT_VISUAL;
+    }
+
     if (season === 'summer' && seasonEvent === 'geshi' && (weather === 'Clear' || weather === 'Morning')) {
         return GESHI_CLEAR_VISUAL;
     }
 
     switch (season) {
         case 'spring':
-            if (weather === 'Clear') return SPRING_CLEAR_VISUAL;
+            if (weather === 'Clear' || weather === 'Morning') return SPRING_CLEAR_VISUAL;
             if (weather === 'Clouds') return SPRING_CLOUDS_VISUAL;
             return defaultVisual;
         case 'summer':
-            return weather === 'Clear' ? SUMMER_CLEAR_VISUAL : defaultVisual;
+            return weather === 'Clear' || weather === 'Morning' ? SUMMER_CLEAR_VISUAL : defaultVisual;
         case 'autumn':
-            if (weather === 'Clear') return AUTUMN_CLEAR_VISUAL;
+            if (weather === 'Clear' || weather === 'Morning') return AUTUMN_CLEAR_VISUAL;
             if (weather === 'Night') return AUTUMN_NIGHT_VISUAL;
             return defaultVisual;
         case 'winter':

--- a/src/components/canvas/effects/SunraysCanvas.tsx
+++ b/src/components/canvas/effects/SunraysCanvas.tsx
@@ -4,12 +4,13 @@ import { motion } from 'framer-motion';
 
 interface Particle { x: number; y: number; vx: number; vy: number; r: number; life: number; phase: number; tone: number; }
 
-type SunraysVariant = 'default' | 'summer-clear' | 'geshi-clear' | 'spring-clear' | 'autumn-clear';
+type SunraysVariant = 'default' | 'summer-clear' | 'geshi-clear' | 'spring-clear' | 'autumn-clear' | 'first-light';
 
 export default function SunraysCanvas({ variant = 'default' }: { variant?: SunraysVariant }) {
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const isSummerClear = variant === 'summer-clear';
     const isGeshiClear = variant === 'geshi-clear';
+    const isFirstLight = variant === 'first-light';
     const isHotClear = isSummerClear || isGeshiClear;
     const isSpringClear = variant === 'spring-clear';
     const isAutumnClear = variant === 'autumn-clear';
@@ -28,7 +29,7 @@ export default function SunraysCanvas({ variant = 'default' }: { variant?: Sunra
         window.addEventListener('resize', resize);
 
         // 浮遊ダスト粒子
-        const particles: Particle[] = Array.from({ length: isHotClear ? 128 : isSpringClear ? 124 : isAutumnClear ? 128 : 90 }, () => ({
+        const particles: Particle[] = Array.from({ length: isFirstLight ? 102 : isHotClear ? 128 : isSpringClear ? 124 : isAutumnClear ? 128 : 90 }, () => ({
             x: Math.random() * window.innerWidth,
             y: Math.random() * window.innerHeight,
             vx: isSpringClear
@@ -57,10 +58,15 @@ export default function SunraysCanvas({ variant = 'default' }: { variant?: Sunra
             const sunX = w * 0.88;
             const sunY = h * 0.08;
             const sunR = Math.max(34, Math.min(w, h) * 0.055);
-            const sunAuraScale = isGeshiClear ? 3.85 : isSummerClear ? 3.45 : isSpringClear ? 2.75 : isAutumnClear ? 2.75 : 2.65;
+            const sunAuraScale = isFirstLight ? 3.05 : isGeshiClear ? 3.85 : isSummerClear ? 3.45 : isSpringClear ? 2.75 : isAutumnClear ? 2.75 : 2.65;
 
             const sunAura = ctx.createRadialGradient(sunX, sunY, sunR * 0.16, sunX, sunY, sunR * sunAuraScale);
-            if (isGeshiClear) {
+            if (isFirstLight) {
+                sunAura.addColorStop(0, 'rgba(255,255,244,0.56)');
+                sunAura.addColorStop(0.22, 'rgba(255,214,165,0.28)');
+                sunAura.addColorStop(0.58, 'rgba(229,143,112,0.12)');
+                sunAura.addColorStop(1, 'rgba(229,143,112,0)');
+            } else if (isGeshiClear) {
                 sunAura.addColorStop(0, 'rgba(255,255,255,0.68)');
                 sunAura.addColorStop(0.22, 'rgba(255,244,188,0.3)');
                 sunAura.addColorStop(0.58, 'rgba(255,226,126,0.13)');
@@ -176,7 +182,9 @@ export default function SunraysCanvas({ variant = 'default' }: { variant?: Sunra
                 } else {
                     ctx.beginPath();
                     ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
-                    ctx.fillStyle = isGeshiClear
+                    ctx.fillStyle = isFirstLight
+                        ? `rgba(255,211,164,${a * 0.72})`
+                        : isGeshiClear
                         ? `rgba(236,250,255,${a * 0.68})`
                         : isSummerClear
                             ? `rgba(248,253,255,${a * 0.76})`
@@ -190,9 +198,11 @@ export default function SunraysCanvas({ variant = 'default' }: { variant?: Sunra
         draw();
 
         return () => { cancelAnimationFrame(raf); window.removeEventListener('resize', resize); };
-    }, [isAutumnClear, isGeshiClear, isHotClear, isSpringClear, isSummerClear]);
+    }, [isAutumnClear, isFirstLight, isGeshiClear, isHotClear, isSpringClear, isSummerClear]);
 
-    const baseGlow = isGeshiClear
+    const baseGlow = isFirstLight
+        ? 'radial-gradient(ellipse 66% 52% at 86% -10%, rgba(255,190,132,0.24) 0%, rgba(232,145,112,0.12) 36%, transparent 74%)'
+        : isGeshiClear
         ? 'radial-gradient(ellipse 70% 54% at 86% -10%, rgba(255,246,192,0.18) 0%, rgba(118,202,255,0.13) 30%, rgba(43,154,240,0.14) 54%, transparent 78%)'
         : isSummerClear
         ? 'radial-gradient(ellipse 66% 54% at 86% -10%, rgba(84,183,255,0.22) 0%, rgba(255,230,156,0.08) 24%, rgba(40,153,238,0.11) 44%, transparent 74%)'
@@ -201,7 +211,9 @@ export default function SunraysCanvas({ variant = 'default' }: { variant?: Sunra
         : isAutumnClear
             ? 'radial-gradient(ellipse 62% 50% at 86% -10%, rgba(255,238,172,0.16) 0%, rgba(218,184,94,0.08) 38%, transparent 74%)'
         : 'radial-gradient(ellipse 62% 50% at 86% -10%, rgba(255,228,172,0.18) 0%, rgba(255,205,150,0.08) 38%, transparent 72%)';
-    const pulseGlow = isGeshiClear
+    const pulseGlow = isFirstLight
+        ? 'radial-gradient(ellipse 60% 46% at 86% -14%, rgba(255,230,177,0.20) 0%, rgba(232,147,111,0.10) 44%, transparent 76%)'
+        : isGeshiClear
         ? 'radial-gradient(ellipse 62% 48% at 86% -14%, rgba(255,252,224,0.16) 0%, rgba(105,199,255,0.13) 44%, transparent 76%)'
         : isSummerClear
         ? 'radial-gradient(ellipse 58% 46% at 86% -14%, rgba(255,248,216,0.18) 0%, rgba(91,195,255,0.12) 44%, transparent 76%)'
@@ -210,7 +222,9 @@ export default function SunraysCanvas({ variant = 'default' }: { variant?: Sunra
         : isAutumnClear
             ? 'radial-gradient(ellipse 58% 46% at 86% -14%, rgba(255,242,190,0.12) 0%, rgba(214,178,88,0.075) 46%, transparent 76%)'
         : 'radial-gradient(ellipse 56% 44% at 86% -14%, rgba(255,236,188,0.16) 0%, rgba(255,214,160,0.06) 44%, transparent 76%)';
-    const wash = isGeshiClear
+    const wash = isFirstLight
+        ? 'linear-gradient(to bottom, rgba(218,140,116,0.10) 0%, rgba(255,211,153,0.055) 36%, transparent 74%)'
+        : isGeshiClear
         ? 'linear-gradient(to bottom, rgba(56,166,245,0.12) 0%, rgba(118,205,255,0.065) 36%, transparent 74%)'
         : isSummerClear
         ? 'linear-gradient(to bottom, rgba(39,157,245,0.11) 0%, rgba(98,192,255,0.055) 34%, transparent 72%)'
@@ -221,6 +235,7 @@ export default function SunraysCanvas({ variant = 'default' }: { variant?: Sunra
         : 'linear-gradient(to bottom, rgba(255,222,180,0.07) 0%, rgba(255,215,170,0.03) 34%, transparent 72%)';
     const summerAtmosphere = 'radial-gradient(ellipse 78% 46% at 48% 4%, rgba(90,184,255,0.14) 0%, rgba(92,177,235,0.08) 42%, rgba(92,177,235,0) 72%), linear-gradient(to bottom, rgba(71,165,235,0.08) 0%, rgba(71,165,235,0.03) 38%, transparent 66%)';
     const geshiAtmosphere = 'radial-gradient(ellipse 82% 48% at 48% 4%, rgba(98,196,255,0.16) 0%, rgba(72,174,245,0.095) 44%, rgba(72,174,245,0) 74%), linear-gradient(to bottom, rgba(54,163,240,0.09) 0%, rgba(118,205,255,0.045) 42%, transparent 70%)';
+    const firstLightAtmosphere = 'radial-gradient(ellipse 66% 52% at 86% -10%, rgba(255,190,132,0.24) 0%, rgba(232,145,112,0.12) 36%, transparent 74%)';
     const springGroundHaze = 'radial-gradient(ellipse 78% 34% at 50% 100%, rgba(255,236,242,0.18) 0%, rgba(255,198,218,0.12) 32%, rgba(255,244,236,0.07) 58%, transparent 82%), linear-gradient(to top, rgba(255,216,228,0.09) 0%, rgba(255,239,232,0.045) 38%, transparent 76%)';
     const autumnGroundHaze = 'radial-gradient(ellipse 78% 32% at 50% 100%, rgba(232,202,112,0.12) 0%, rgba(196,151,74,0.07) 34%, rgba(248,226,154,0.045) 60%, transparent 84%), linear-gradient(to top, rgba(199,157,78,0.06) 0%, rgba(238,213,139,0.028) 40%, transparent 78%)';
 
@@ -231,10 +246,10 @@ export default function SunraysCanvas({ variant = 'default' }: { variant?: Sunra
             transition={{ duration: 2 }}
         >
             {/* 朝日のやわらかい暖色グロー */}
-            {isHotClear && (
+            {(isHotClear || isFirstLight) && (
                 <div
                     className="absolute inset-0"
-                    style={{ background: isGeshiClear ? geshiAtmosphere : summerAtmosphere }}
+                    style={{ background: isFirstLight ? firstLightAtmosphere : isGeshiClear ? geshiAtmosphere : summerAtmosphere }}
                 />
             )}
             <div

--- a/src/components/dom/TopLeftMenu.tsx
+++ b/src/components/dom/TopLeftMenu.tsx
@@ -2,9 +2,9 @@
 
 import Link from 'next/link';
 import { useEffect, useRef, useState } from 'react';
-import { useSearchParams } from 'next/navigation';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useStore, type SeasonEventType, type SeasonType, type WeatherType } from '@/store';
+import { buildWorldStateQuery } from '@/lib/worldState';
 import { useWorkNavigation } from './useWorkNavigation';
 
 const MENU_COMMANDS = {
@@ -38,6 +38,7 @@ export default function TopLeftMenu() {
     const cliRef = useRef<HTMLDivElement>(null);
     const cliInputRef = useRef<HTMLInputElement>(null);
     const router = useRouter();
+    const pathname = usePathname();
     const searchParams = useSearchParams();
     const lang = searchParams.get('lang') === 'en' ? 'en' : 'ja';
     const setWorldState = useStore((state) => state.setWorldState);
@@ -112,6 +113,16 @@ export default function TopLeftMenu() {
         setCliHistory((prev) => [...prev, entry].slice(-8));
     };
 
+    const applyWorldState = (next: Partial<{ weather: WeatherType; season: SeasonType; seasonEvent: SeasonEventType }>) => {
+        setWorldState(next);
+        const resolved = useStore.getState();
+        router.replace(`${pathname}?${buildWorldStateQuery({
+            weather: resolved.weather,
+            season: resolved.season,
+            seasonEvent: resolved.seasonEvent,
+        }, lang)}`, { scroll: false });
+    };
+
     const handleCliCommand = (rawInput: string) => {
         const command = rawInput.trim();
         if (!command) return;
@@ -119,7 +130,7 @@ export default function TopLeftMenu() {
         appendHistory({ tone: 'info', text: `$ ${command}` });
 
         if (command.toLowerCase() === 'help') {
-            appendHistory({ tone: 'info', text: 'Available: sudo make rain|snow|clouds|clear|thunder|night|spring|summer|autumn|winter|sakura|hanagumori|geshi|tsuyu|momiji|tsukimi|yukigeshiki|season-clear, help, exit' });
+            appendHistory({ tone: 'info', text: 'Available: sudo make rain|snow|clouds|clear|thunder|night|spring|summer|autumn|winter|sakura|hanagumori|geshi|tsuyu|hatsuhinode|momiji|tsukimi|yukigeshiki|season-clear, help, exit' });
             return;
         }
 
@@ -164,7 +175,7 @@ export default function TopLeftMenu() {
 
             const nextPreset = presetMap[token];
             if (nextPreset) {
-                setWorldState({
+                applyWorldState({
                     season: nextPreset.season,
                     seasonEvent: nextPreset.seasonEvent ?? 'none',
                     weather: nextPreset.weather,
@@ -175,7 +186,7 @@ export default function TopLeftMenu() {
 
             const nextSeason = seasonMap[token];
             if (nextSeason) {
-                setWorldState({ season: nextSeason, seasonEvent: 'none' });
+                applyWorldState({ season: nextSeason, seasonEvent: 'none' });
                 appendHistory({ tone: 'ok', text: `[ok] season switched to ${nextSeason.toUpperCase()}` });
                 return;
             }
@@ -186,7 +197,7 @@ export default function TopLeftMenu() {
                 return;
             }
 
-            setWorldState({ weather: nextWeather, seasonEvent: 'none' });
+            applyWorldState({ weather: nextWeather, seasonEvent: 'none' });
             appendHistory({ tone: 'ok', text: `[ok] weather switched to ${nextWeather.toUpperCase()}` });
             return;
         }

--- a/src/components/dom/WeatherDebugSelector.tsx
+++ b/src/components/dom/WeatherDebugSelector.tsx
@@ -1,6 +1,9 @@
 'use client';
 
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useStore, WeatherType } from '@/store';
+import { useWorldState } from '@/components/WorldStateProvider';
+import { buildWorldStateQuery } from '@/lib/worldState';
 
 const WEATHERS: WeatherType[] = ['Morning', 'Clouds', 'Rain', 'Thunder', 'Snow', 'Night'];
 
@@ -25,7 +28,13 @@ const LABEL: Record<WeatherType, string> = {
 };
 
 export default function WeatherDebugSelector() {
-    const { weather, setWorldState } = useStore();
+    const setWorldState = useStore((state) => state.setWorldState);
+    const worldState = useWorldState();
+    const { weather } = worldState;
+    const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+    const lang = searchParams.get('lang') === 'en' ? 'en' : 'ja';
 
     return (
         <div className="flex flex-col gap-1 mt-2 border-l border-gray-800 pl-4 pointer-events-none">
@@ -34,7 +43,11 @@ export default function WeatherDebugSelector() {
                 {WEATHERS.map((w) => (
                     <button
                         key={w}
-                        onClick={() => setWorldState({ weather: w })}
+                        onClick={() => {
+                            const nextState = { ...worldState, weather: w };
+                            setWorldState({ weather: w });
+                            router.replace(`${pathname}?${buildWorldStateQuery(nextState, lang)}`, { scroll: false });
+                        }}
                         className={`pointer-events-auto touch-manipulation text-[10px] font-mono tracking-wider px-1.5 py-0.5 border rounded-sm transition-all ${weather === w
                             ? `${COLOR[w]} bg-white/10`
                             : 'text-gray-600 border-gray-700 hover:text-gray-400 hover:border-gray-500'

--- a/src/components/dom/useWorkNavigation.ts
+++ b/src/components/dom/useWorkNavigation.ts
@@ -5,6 +5,8 @@ import { useCallback, useEffect, useRef } from 'react';
 import { buildWorldStateQuery } from '@/lib/worldState';
 import { type TransitionType } from '@/lib/soundProfile';
 import { useStore } from '@/store';
+import { useWorldState } from '@/components/WorldStateProvider';
+import type { WorldState } from '@/lib/worldStateTypes';
 
 type WorkId = '01' | '02' | '03' | '04' | '05';
 
@@ -25,6 +27,7 @@ export function useWorkNavigation(lang: 'ja' | 'en') {
     const router = useRouter();
     const setActiveWork = useStore((state) => state.setActiveWork);
     const setTransitionType = useStore((state) => state.setTransitionType);
+    const worldState = useWorldState();
     const timersRef = useRef<number[]>([]);
     const navigationVersionRef = useRef(0);
 
@@ -39,8 +42,7 @@ export function useWorkNavigation(lang: 'ja' | 'en') {
     const navigateToWork = useCallback((workId: string) => {
         if (!isWorkId(workId)) return false;
 
-        const currentState = useStore.getState();
-        const plan = getNavigationPlan(workId, lang, currentState);
+        const plan = getNavigationPlan(workId, lang, worldState);
         if (!plan) return false;
 
         clearTimers();
@@ -66,7 +68,7 @@ export function useWorkNavigation(lang: 'ja' | 'en') {
 
         timersRef.current.push(routeTimer);
         return true;
-    }, [clearTimers, lang, router, setActiveWork, setTransitionType]);
+    }, [clearTimers, lang, router, setActiveWork, setTransitionType, worldState]);
 
     return navigateToWork;
 }
@@ -78,7 +80,7 @@ function isWorkId(value: string): value is WorkId {
 function getNavigationPlan(
     workId: WorkId,
     lang: 'ja' | 'en',
-    state: ReturnType<typeof useStore.getState>,
+    state: WorldState,
 ): NavigationPlan | null {
     if (workId === '02') {
         const transition = state.weather === 'Rain'

--- a/src/lib/otenkigurashiSeasonal.test.ts
+++ b/src/lib/otenkigurashiSeasonal.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { AUTUMN_LEAF_SPECS, SPRING_PETAL_SPECS } from './otenkigurashiSeasonal';
+
+describe('seasonal visual tokens', () => {
+    it('keeps deterministic spring particle specs in one shared stream', () => {
+        expect(SPRING_PETAL_SPECS).toHaveLength(24);
+        expect(SPRING_PETAL_SPECS[0]).toEqual({
+            left: expect.any(Number),
+            delay: expect.any(Number),
+            duration: expect.any(Number),
+            size: expect.any(Number),
+            drift: expect.any(Number),
+            rotate: expect.any(Number),
+        });
+        expect(SPRING_PETAL_SPECS.every((petal) => petal.duration >= 12 && petal.duration < 19)).toBe(true);
+    });
+
+    it('keeps autumn leaf specs available as the shared transition contract', () => {
+        expect(AUTUMN_LEAF_SPECS).toHaveLength(20);
+        expect(AUTUMN_LEAF_SPECS.every((leaf) => leaf.duration >= 9 && leaf.duration < 16)).toBe(true);
+    });
+});

--- a/src/lib/otenkigurashiSeasonal.ts
+++ b/src/lib/otenkigurashiSeasonal.ts
@@ -6,6 +6,12 @@ export const AUTUMN_BACKGROUND_GRADIENT =
 export const WINTER_BACKGROUND_GRADIENT =
     'linear-gradient(180deg, #aebdcb 0%, #d8e4ec 48%, #ffffff 100%)';
 
+export const FIRST_LIGHT_BACKGROUND_GRADIENT =
+    'linear-gradient(180deg, #8f9eb8 0%, #d5a08d 42%, #f2c27b 72%, #fff0c9 100%)';
+
+export const FIRST_LIGHT_ATMOSPHERE_GRADIENT =
+    'radial-gradient(ellipse 82% 44% at 82% 8%, rgba(255,193,125,0.24), transparent 62%), linear-gradient(180deg, rgba(218,140,116,0.10), rgba(255,220,159,0.08) 62%, transparent)';
+
 export const SPRING_FLOWER_CLOUDY_BACKGROUND_GRADIENT =
     'linear-gradient(180deg, #c5d1d9 0%, #e6e9e7 52%, #f3e8ed 100%)';
 
@@ -42,6 +48,19 @@ export type FlowerCloudyPetalSpec = {
     drift: number;
     rotate: number;
 };
+
+export type SpringPetalSpec = FlowerCloudyPetalSpec;
+
+// Transition and final Sakura layers use one deterministic stream. This keeps
+// positions, drift, and fall speed continuous at the route boundary.
+export const SPRING_PETAL_SPECS: SpringPetalSpec[] = Array.from({ length: 24 }, (_, index) => ({
+    left: seasonalValue(index, 1) * 100,
+    delay: seasonalValue(index, 2) * 4,
+    duration: 12 + seasonalValue(index, 3) * 7,
+    size: 7 + seasonalValue(index, 4) * 8,
+    drift: -48 + seasonalValue(index, 5) * 96,
+    rotate: seasonalValue(index, 6) * 360,
+}));
 
 // The transition and final page share this exact dataset so flower-cloudy
 // petals keep their speed, position, and drift across the route boundary.

--- a/src/lib/seasonResolver.test.ts
+++ b/src/lib/seasonResolver.test.ts
@@ -4,6 +4,13 @@ import { resolveSeasonState } from './seasonResolver';
 const japanDate = (date: string) => new Date(`${date}T03:00:00.000Z`);
 
 describe('resolveSeasonState', () => {
+    it('resolves first light on New Year morning', () => {
+        expect(resolveSeasonState(japanDate('2026-01-01'))).toEqual({
+            season: 'winter',
+            seasonEvent: 'first_light',
+        });
+    });
+
     it('resolves the regular season boundaries', () => {
         expect(resolveSeasonState(japanDate('2026-03-01'))).toEqual({ season: 'spring', seasonEvent: 'none' });
         expect(resolveSeasonState(japanDate('2026-06-06'))).toEqual({ season: 'summer', seasonEvent: 'none' });

--- a/src/lib/seasonResolver.ts
+++ b/src/lib/seasonResolver.ts
@@ -31,6 +31,9 @@ function resolveSeason(month: number): SeasonType {
 }
 
 function resolveSeasonEvent(month: number, day: number): SeasonEventType {
+    // 元日は初日の出の演出を選ぶ。weather=Morning のときだけ表示側で有効化する。
+    if (month === 1 && day === 1) return 'first_light';
+
     // 夏至は梅雨の雰囲気より優先して、専用の演出を選ぶ。
     if (month === 6 && day === 21) return 'geshi';
 

--- a/src/lib/worldState.test.ts
+++ b/src/lib/worldState.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseWorldStateRecord, resolveWorldState } from './worldState';
+import { canonicalizeWorldStateQuery, parseWorldStateParams, parseWorldStateRecord, resolveWorldState } from './worldState';
 
 describe('parseWorldStateRecord', () => {
     it('clears tsuyu when the route explicitly selects a non-summer season', () => {
@@ -45,6 +45,30 @@ describe('parseWorldStateRecord', () => {
         });
     });
 
+    it('clears geshi when the season or weather is incompatible', () => {
+        expect(resolveWorldState(
+            { season: 'autumn', weather: 'Clear', seasonEvent: 'geshi' },
+            { weather: 'Clear', season: 'none', seasonEvent: 'none' },
+        ).seasonEvent).toBe('none');
+
+        expect(resolveWorldState(
+            { season: 'summer', weather: 'Rain', seasonEvent: 'geshi' },
+            { weather: 'Clear', season: 'none', seasonEvent: 'none' },
+        ).seasonEvent).toBe('none');
+    });
+
+    it('clears tsuyu when the weather leaves its supported set', () => {
+        expect(resolveWorldState(
+            { season: 'summer', weather: 'Snow', seasonEvent: 'tsuyu' },
+            { weather: 'Clear', season: 'none', seasonEvent: 'none' },
+        ).seasonEvent).toBe('none');
+
+        expect(resolveWorldState(
+            { season: 'summer', weather: 'Clouds', seasonEvent: 'tsuyu' },
+            { weather: 'Clear', season: 'none', seasonEvent: 'none' },
+        ).seasonEvent).toBe('tsuyu');
+    });
+
     it('allows first light only during the Morning weather state', () => {
         expect(resolveWorldState(
             { season: 'winter', seasonEvent: 'first_light', weather: 'Rain' },
@@ -55,5 +79,22 @@ describe('parseWorldStateRecord', () => {
             { season: 'winter', seasonEvent: 'first_light', weather: 'Morning' },
             { weather: 'Clear', season: 'none', seasonEvent: 'none' },
         ).seasonEvent).toBe('first_light');
+    });
+
+    it('turns an explicitly invalid URL event into none', () => {
+        expect(parseWorldStateParams(new URLSearchParams('weather=Rain&season=summer&seasonEvent=unknown'))).toEqual({
+            weather: 'Rain',
+            season: 'summer',
+            seasonEvent: 'none',
+        });
+    });
+
+    it('canonicalizes a partial URL into one resolved snapshot', () => {
+        const query = canonicalizeWorldStateQuery(
+            new URLSearchParams('lang=ja&weather=Snow'),
+            { weather: 'Snow', season: 'winter', seasonEvent: 'first_light' },
+        );
+
+        expect(query.toString()).toBe('lang=ja&weather=Snow&season=winter&seasonEvent=none');
     });
 });

--- a/src/lib/worldState.ts
+++ b/src/lib/worldState.ts
@@ -12,10 +12,37 @@ export const DEFAULT_WORLD_STATE: WorldState = {
     seasonEvent: 'none',
 };
 
-export function normalizeSeasonEvent(season: SeasonType, seasonEvent: SeasonEventType): SeasonEventType {
-    if (seasonEvent === 'tsuyu' && season !== 'summer') return 'none';
-    if (seasonEvent === 'first_light' && season !== 'winter') return 'none';
-    return seasonEvent;
+type SeasonEventRule = {
+    season: SeasonType;
+    weather: readonly WeatherType[];
+};
+
+export const SEASON_EVENT_RULES: Record<Exclude<SeasonEventType, 'none'>, SeasonEventRule> = {
+    geshi: { season: 'summer', weather: ['Clear', 'Morning'] },
+    tsuyu: { season: 'summer', weather: ['Clear', 'Morning', 'Clouds', 'Rain'] },
+    first_light: { season: 'winter', weather: ['Morning'] },
+};
+
+export function isSeasonEventAllowed(
+    season: SeasonType | undefined,
+    seasonEvent: SeasonEventType,
+    weather?: WeatherType,
+): boolean {
+    if (seasonEvent === 'none') return true;
+
+    const rule = SEASON_EVENT_RULES[seasonEvent];
+    if (!rule) return false;
+    if (season !== undefined && season !== rule.season) return false;
+    if (weather !== undefined && !rule.weather.includes(weather)) return false;
+    return true;
+}
+
+export function normalizeSeasonEvent(
+    season: SeasonType | undefined,
+    seasonEvent: SeasonEventType,
+    weather?: WeatherType,
+): SeasonEventType {
+    return isSeasonEventAllowed(season, seasonEvent, weather) ? seasonEvent : 'none';
 }
 
 /**
@@ -24,13 +51,10 @@ export function normalizeSeasonEvent(season: SeasonType, seasonEvent: SeasonEven
  * and page components from disagreeing about the active seasonal event.
  */
 export function normalizeWorldState(state: WorldState): WorldState {
-    const normalizedSeasonEvent = normalizeSeasonEvent(state.season, state.seasonEvent);
+    const normalizedSeasonEvent = normalizeSeasonEvent(state.season, state.seasonEvent, state.weather);
     return {
         ...state,
-        seasonEvent: normalizedSeasonEvent === 'first_light'
-            && (state.season !== 'winter' || state.weather !== 'Morning')
-            ? 'none'
-            : normalizedSeasonEvent,
+        seasonEvent: normalizedSeasonEvent,
     };
 }
 
@@ -44,15 +68,22 @@ export function resolveWorldState(partial: Partial<WorldState>, fallback: WorldS
 
 export function canonicalizeWorldStateQuery(source: URLSearchParams, state: WorldState) {
     const params = new URLSearchParams(source.toString());
-    if (params.has('weather')) params.set('weather', state.weather);
-    if (params.has('season')) params.set('season', state.season);
-    if (params.has('seasonEvent')) params.set('seasonEvent', state.seasonEvent);
+    const resolvedState = normalizeWorldState(state);
+    // A route that opts into world state must carry one complete snapshot.
+    // Keeping partial query strings allows omitted seasonal fields to leak
+    // back in from the Zustand store on the next navigation.
+    params.set('weather', resolvedState.weather);
+    params.set('season', resolvedState.season);
+    params.set('seasonEvent', resolvedState.seasonEvent);
     return params;
 }
 
 type SearchValue = string | string[] | undefined | null;
 type SearchRecord = Record<string, SearchValue>;
-type SearchParamsLike = { get: (name: string) => string | null };
+type SearchParamsLike = {
+    get: (name: string) => string | null;
+    has?: (name: string) => boolean;
+};
 
 const firstValue = (value: SearchValue) => Array.isArray(value) ? value[0] : value ?? null;
 
@@ -64,12 +95,16 @@ export function parseWorldStateRecord(source: SearchRecord): Partial<WorldState>
     const parsedSeasonEvent = seasonEvent && VALID_SEASON_EVENTS.includes(seasonEvent as SeasonEventType)
         ? seasonEvent as SeasonEventType
         : null;
-    const normalizedSeasonEvent = parsedSeason && parsedSeasonEvent
-        ? normalizeSeasonEvent(parsedSeason, parsedSeasonEvent)
-        : parsedSeasonEvent;
+    const parsedWeather = weather && VALID_WEATHERS.includes(weather as WeatherType)
+        ? weather as WeatherType
+        : null;
+    const hasSeasonEvent = seasonEvent !== undefined && seasonEvent !== null;
+    const normalizedSeasonEvent = hasSeasonEvent
+        ? normalizeSeasonEvent(parsedSeason ?? undefined, parsedSeasonEvent ?? 'none', parsedWeather ?? undefined)
+        : null;
 
     return {
-        ...(weather && VALID_WEATHERS.includes(weather as WeatherType) ? { weather: weather as WeatherType } : {}),
+        ...(parsedWeather ? { weather: parsedWeather } : {}),
         ...(parsedSeason ? { season: parsedSeason } : {}),
         ...(normalizedSeasonEvent ? { seasonEvent: normalizedSeasonEvent } : {}),
     };
@@ -79,15 +114,18 @@ export function parseWorldStateParams(source: SearchParamsLike): Partial<WorldSt
     return parseWorldStateRecord({
         weather: source.get('weather'),
         season: source.get('season'),
-        seasonEvent: source.get('seasonEvent'),
+        // Preserve an explicitly supplied invalid event as `none` instead of
+        // allowing a stale event from the Zustand fallback to leak into the URL state.
+        seasonEvent: source.has?.('seasonEvent') ? source.get('seasonEvent') : undefined,
     });
 }
 
 export function buildWorldStateQuery(state: WorldState, lang?: string) {
+    const resolvedState = normalizeWorldState(state);
     const params = new URLSearchParams();
     if (lang) params.set('lang', lang);
-    params.set('weather', state.weather);
-    params.set('season', state.season);
-    params.set('seasonEvent', state.seasonEvent);
+    params.set('weather', resolvedState.weather);
+    params.set('season', resolvedState.season);
+    params.set('seasonEvent', resolvedState.seasonEvent);
     return params.toString();
 }

--- a/src/lib/worldVisualProfile.test.ts
+++ b/src/lib/worldVisualProfile.test.ts
@@ -25,4 +25,20 @@ describe('getWorldVisualProfile', () => {
         expect(profile.showSpring).toBe(false);
         expect(profile.cloudsVariant).toBe('spring-clouds');
     });
+
+    it('selects first light only for the winter Morning snapshot', () => {
+        const morning = getWorldVisualProfile({ weather: 'Morning', season: 'winter', seasonEvent: 'first_light' });
+        const snow = getWorldVisualProfile({ weather: 'Snow', season: 'winter', seasonEvent: 'first_light' });
+
+        expect(morning.showFirstLight).toBe(true);
+        expect(morning.sunraysVariant).toBe('first-light');
+        expect(snow.showFirstLight).toBe(false);
+        expect(snow.sunraysVariant).toBe('default');
+    });
+
+    it('uses the seasonal clear profile for Morning across screens', () => {
+        expect(getWorldVisualProfile({ weather: 'Morning', season: 'spring', seasonEvent: 'none' }).showSpring).toBe(true);
+        expect(getWorldVisualProfile({ weather: 'Morning', season: 'summer', seasonEvent: 'none' }).showSummer).toBe(true);
+        expect(getWorldVisualProfile({ weather: 'Morning', season: 'autumn', seasonEvent: 'none' }).showAutumn).toBe(true);
+    });
 });

--- a/src/lib/worldVisualProfile.transition.test.ts
+++ b/src/lib/worldVisualProfile.transition.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { getWorldVisualProfile } from './worldVisualProfile';
+import type { WorldState } from './worldState';
+
+const snapshots: WorldState[] = [
+    { weather: 'Morning', season: 'winter', seasonEvent: 'first_light' },
+    { weather: 'Rain', season: 'summer', seasonEvent: 'tsuyu' },
+    { weather: 'Clear', season: 'autumn', seasonEvent: 'none' },
+    { weather: 'Snow', season: 'winter', seasonEvent: 'none' },
+];
+
+describe('transition/final visual state contract', () => {
+    it('derives one profile for both transition and final consumers', () => {
+        for (const snapshot of snapshots) {
+            const transitionProfile = getWorldVisualProfile(snapshot);
+            const finalProfile = getWorldVisualProfile({ ...snapshot });
+
+            expect(finalProfile).toEqual(transitionProfile);
+        }
+    });
+
+    it('does not expose an event visual when the snapshot is illegal', () => {
+        const profile = getWorldVisualProfile({ weather: 'Snow', season: 'summer', seasonEvent: 'tsuyu' });
+
+        expect(profile.showTsuyu).toBe(false);
+        expect(profile.showFirstLight).toBe(false);
+        expect(profile.showGeshi).toBe(false);
+    });
+});

--- a/src/lib/worldVisualProfile.ts
+++ b/src/lib/worldVisualProfile.ts
@@ -1,16 +1,17 @@
-import type { WorldState } from './worldState';
+import { isSeasonEventAllowed, type WorldState } from './worldState';
 
 export type WorldVisualProfile = WorldState & {
     isClear: boolean;
     isGeshiEvent: boolean;
     showTsuyu: boolean;
+    showFirstLight: boolean;
     showSpring: boolean;
     showFlowerCloudy: boolean;
     showGeshi: boolean;
     showSummer: boolean;
     showAutumn: boolean;
     showWinterSnow: boolean;
-    sunraysVariant: 'geshi-clear' | 'summer-clear' | 'spring-clear' | 'autumn-clear' | 'default';
+    sunraysVariant: 'geshi-clear' | 'summer-clear' | 'spring-clear' | 'autumn-clear' | 'first-light' | 'default';
     cloudsVariant: 'spring-clouds' | 'default';
     nightVariant: 'autumn-night' | 'default';
     snowVariant: 'winter-snow' | 'default';
@@ -27,32 +28,33 @@ export function getWorldVisualProfile(
     const { weather, season, seasonEvent } = worldState;
     const isClear = weather === 'Clear' || weather === 'Morning';
     const isGeshiEvent = season === 'summer' && seasonEvent === 'geshi';
-    const showTsuyu = season === 'summer'
-        && seasonEvent === 'tsuyu'
-        && (isClear || weather === 'Clouds' || weather === 'Rain');
+    const showTsuyu = isSeasonEventAllowed(season, seasonEvent, weather) && seasonEvent === 'tsuyu';
+    const showFirstLight = isSeasonEventAllowed(season, seasonEvent, weather) && seasonEvent === 'first_light';
     const showSpring = season === 'spring' && isClear && !showTsuyu;
     const showFlowerCloudy = season === 'spring' && weather === 'Clouds' && !showTsuyu;
-    const showGeshi = isGeshiEvent && isClear;
+    const showGeshi = isSeasonEventAllowed(season, seasonEvent, weather) && isGeshiEvent && isClear;
     const showSummer = season === 'summer' && isClear && !showGeshi && !showTsuyu;
     const showAutumn = season === 'autumn' && isClear && !showTsuyu;
     const showWinterSnow = season === 'winter' && weather === 'Snow' && !showTsuyu;
     const includeGeshiSun = options.includeGeshiSun !== false;
 
-    const sunraysVariant = !includeGeshiSun
-        ? season === 'summer' && weather === 'Clear'
+    const sunraysVariant = showFirstLight
+        ? 'first-light'
+        : !includeGeshiSun
+        ? season === 'summer' && isClear
             ? 'summer-clear'
-            : season === 'spring' && weather === 'Clear'
+            : season === 'spring' && isClear
                 ? 'spring-clear'
-                : season === 'autumn' && weather === 'Clear'
+                : season === 'autumn' && isClear
                     ? 'autumn-clear'
                     : 'default'
-        : isGeshiEvent && weather === 'Clear'
+        : showGeshi
             ? 'geshi-clear'
-            : season === 'summer' && weather === 'Clear'
+            : season === 'summer' && isClear
                 ? 'summer-clear'
-                : season === 'spring' && weather === 'Clear'
+                : season === 'spring' && isClear
                     ? 'spring-clear'
-                    : season === 'autumn' && weather === 'Clear'
+                    : season === 'autumn' && isClear
                         ? 'autumn-clear'
                         : 'default';
 
@@ -63,6 +65,7 @@ export function getWorldVisualProfile(
         isClear,
         isGeshiEvent,
         showTsuyu,
+        showFirstLight,
         showSpring,
         showFlowerCloudy,
         showGeshi,

--- a/src/store/index.test.ts
+++ b/src/store/index.test.ts
@@ -39,6 +39,22 @@ describe('world state store', () => {
         expect(useStore.getState().seasonEvent).toBe('none');
     });
 
+    it('clears an incompatible seasonal event when only weather changes', () => {
+        useStore.getState().setWorldState({
+            weather: 'Rain',
+            season: 'summer',
+            seasonEvent: 'tsuyu',
+        });
+
+        useStore.getState().setWeather('Snow');
+
+        expect(useStore.getState()).toMatchObject({
+            weather: 'Snow',
+            season: 'summer',
+            seasonEvent: 'none',
+        });
+    });
+
     it('keeps an explicit season clear separate from automatic resolution', () => {
         useStore.getState().setWorldState({ season: 'none', seasonEvent: 'none' });
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -63,10 +63,16 @@ export const useStore = create<AppState>((set) => ({
         seasonResolution: next.season === undefined ? current.seasonResolution : 'manual',
         seasonEventResolution: next.seasonEvent === undefined ? current.seasonEventResolution : 'manual',
     })),
-    initializeWorldState: (next) => set((current) => normalizeWorldState({
-        weather: next.weather ?? current.weather,
-        season: next.season ?? current.season,
-        seasonEvent: next.seasonEvent ?? current.seasonEvent,
+    initializeWorldState: (next) => set((current) => ({
+        ...normalizeWorldState({
+            weather: next.weather ?? current.weather,
+            season: next.season ?? current.season,
+            seasonEvent: next.seasonEvent ?? current.seasonEvent,
+        }),
+        // Server initialization is a fresh snapshot, not a manual override.
+        // Route parameters can opt fields back into manual mode afterwards.
+        seasonResolution: 'auto',
+        seasonEventResolution: 'auto',
     })),
     setActivity: (level) => set({ githubActivityLevel: level }),
     setActiveWork: (id) => set({ activeWorkId: id }),


### PR DESCRIPTION
## Summary

- Canonicalize the weather, season, and seasonal-event snapshot across routes and the client store.
- Centralize seasonal visual profiles and deterministic particle tokens, including first-light.
- Propagate the resolved snapshot through home, card, Otenki Gurashi, Denshouo, transitions, and visual effects.
- Keep the momiji cursor fixed and match Tenchan's hair ornament shape, colors, and linework.
- Add unit and E2E coverage for seasonal transitions, illegal events, and cross-screen state consistency.

## Why

The same world state was being resolved in multiple places, which allowed stale or partial query parameters to leak into transitions and final screens. This PR gives state normalization one responsibility and lets visual consumers read one resolved profile.

## Validation

- `npx vitest run src` — 8 files, 32 tests passed
- `npx tsc --noEmit` — passed
- `git diff --check` — passed
- `npm run lint` — did not finish in this environment and was stopped after no diagnostics were emitted
- Playwright browser launch remains environment-limited by the existing Chromium `spawn EPERM` issue

## Commit structure

1. `refactor: canonicalize seasonal world state`
2. `feat: define seasonal visual profiles`
3. `refactor: propagate canonical world state`
4. `feat: align seasonal atmosphere and cursor effects`
5. `test: cover seasonal transition contracts`