### PR TITLE
fix: READMEカードの背景星を非表示にする

### DIFF
--- a/src/app/card/CardScene.tsx
+++ b/src/app/card/CardScene.tsx
@@ -23,9 +23,11 @@ function CardCameraRig() {
 export default function CardScene({
     weather,
     activityLevel,
+    showBackgroundStars = true,
 }: {
     weather: WeatherType;
     activityLevel: number;
+    showBackgroundStars?: boolean;
 }) {
     return (
         <Canvas
@@ -47,7 +49,7 @@ export default function CardScene({
 
                 <Weather weatherOverride={weather} />
 
-                <Stars radius={100} depth={50} count={640} factor={1.5} saturation={0} fade speed={0.35} />
+                <Stars radius={100} depth={50} count={showBackgroundStars ? 640 : 0} factor={1.5} saturation={0} fade speed={0.35} />
 
                 <EffectComposer multisampling={8}>
                     <Bloom

--- a/src/app/card/page.tsx
+++ b/src/app/card/page.tsx
@@ -48,7 +48,7 @@ export default async function CardPage({
             <div className="pointer-events-none absolute inset-x-0 bottom-0 h-px bg-linear-to-r from-transparent via-blue-300/40 to-transparent" />
 
             <div className="absolute inset-0 z-0">
-                <CardScene weather={visualWeather} activityLevel={data.activityLevel} />
+                <CardScene weather={visualWeather} activityLevel={data.activityLevel} showBackgroundStars={false} />
             </div>
 
             <div className="pointer-events-none absolute inset-0 z-10">


### PR DESCRIPTION
## 概要

README用の `/card` プレビューで、背景にランダム表示される星を非表示にしました。球体周辺の点や既存の演出は変更していません。

## 変更内容

- `CardScene` に `showBackgroundStars` オプションを追加（既定値は `true`）
- `/card` だけ `showBackgroundStars={false}` を指定
- 通常画面やOGPなど、他の利用箇所は従来どおり背景星を表示

## 確認

- 対象ファイルの ESLint: pass
- `tsc --noEmit`: pass
- `git diff --check`: pass
- `/card` の表示を確認

## レビュー観点

- README用カードの背景星だけが消えていること
- 球体周辺の粒子、軌道線、色、アニメーションに変更がないこと
- `CardScene` の既定値により、他画面の表示が変わっていないこと