### PR TITLE
fix: reduce mobile snowflake size

### DIFF
--- a/src/app/otenkigurashi/OtenkiGurashiClient.tsx
+++ b/src/app/otenkigurashi/OtenkiGurashiClient.tsx
@@ -361,7 +361,7 @@ export default function OtenkiGurashiClient() {
                 {displayedWeather === 'Snow' && (
                     <>
                         <div className="fixed inset-0 pointer-events-none z-20">
-                            <SnowCanvas density={1.45} />
+                            <SnowCanvas density={1.45} mobileScale={0.65} />
                         </div>
                     </>
                 )}

--- a/src/components/canvas/effects/SnowCanvas.tsx
+++ b/src/components/canvas/effects/SnowCanvas.tsx
@@ -126,7 +126,14 @@ export default function SnowCanvas({
                 if (f.x < -6) f.x = w + 6;
 
                 const rOffset = Math.ceil(f.r);
-                ctx.drawImage(flakeCanvases[i], f.x - rOffset, f.y - rOffset);
+                const drawSize = rOffset * 2;
+                ctx.drawImage(
+                    flakeCanvases[i],
+                    f.x - rOffset,
+                    f.y - rOffset,
+                    drawSize,
+                    drawSize,
+                );
             }
 
             if (isWinterSnow) {


### PR DESCRIPTION
## 概要
スマホ表示のおてんきぐらしで雪粒が大きく見えるため、雪の表示サイズだけを調整しました。

## 変更内容
- `SnowCanvas` の高DPR描画時に、オフスクリーンCanvasの表示サイズを明示して意図しない拡大を防止
- `/otenkigurashi` のスマホ雪を `mobileScale={0.65}` に調整

## 変更していないもの
- PC表示の雪サイズ
- 雪粒の密度
- 他の天候・季節演出
- 既存の未コミット変更

## 確認ポイント
スマホ幅で `weather=Snow` の `/otenkigurashi` を開き、雪粒が大きすぎず、見えなくなりすぎていないか確認してください。