### PR TITLE
fix: repair GitHub README GIF layout

### DIFF
--- a/.github/workflows/update-weather.yml
+++ b/.github/workflows/update-weather.yml
@@ -37,9 +37,6 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
 
       - name: Run recording script
-        env:
-          WEATHER_RECORD_WIDTH: 1200
-          WEATHER_RECORD_HEIGHT: 600
         run: npx --yes tsx scripts/record_weather.ts
 
       - name: Convert WebM to GIF
@@ -50,7 +47,7 @@ jobs:
             echo "No WebM file was recorded."
             exit 1
           fi
-          ffmpeg -y -i "$WEBM_FILE" -ss 15 -t 5 -vf "setpts=1.25*PTS,fps=16,scale=1200:-1:flags=lanczos,split[s0][s1];[s0]palettegen=max_colors=256:stats_mode=diff[p];[s1][p]paletteuse=dither=sierra2_4a:diff_mode=rectangle" -loop 0 preview.gif
+          ffmpeg -y -i "$WEBM_FILE" -ss 15 -t 5 -vf "setpts=1.25*PTS,fps=16,scale=800:-1:flags=lanczos,split[s0][s1];[s0]palettegen=max_colors=256:stats_mode=diff[p];[s1][p]paletteuse=dither=sierra2_4a:diff_mode=rectangle" -loop 0 preview.gif
           rm -rf videos/
 
       - name: Commit GIF to assets branch

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ DiscordやXなどのSNS用OGPは、過去にも使っていたWAKATOロゴを `s
 
 ### README Preview GIF
 
-README上部のプレビューは `/card` を `1200x600` で録画したライブ天候GIFです。生成物は `preview-assets` ブランチへ分離して保存し、READMEから `raw.githubusercontent.com` 経由で参照しています。
+README上部のプレビューは `/card` を `800x400` で録画したライブ天候GIFです。生成物は `preview-assets` ブランチへ分離して保存し、READMEから `raw.githubusercontent.com` 経由で参照しています。
 
 ```text
 main


### PR DESCRIPTION
## 概要
GitHub README用GIFの録画viewportを、固定サイズのカードに合わせて800x400へ戻します。

## 原因
- ワークフローだけ1200x600へ変更されていた
- `/card` は800x400固定
- `WeatherEffectsOverlay` の固定Canvasが1200x600全体へ描画され、右側と下側に太陽・粒子が漏れていた
- README表示時にカードが533x267まで縮小されていた

## 変更
- `update-weather.yml` の録画サイズ指定を削除し、`record_weather.ts` の800x400既定値を使用
- FFmpeg出力を800px幅に合わせて、READMEの実表示サイズと一致
- READMEの生成GIF説明を800x400へ更新

## 変更していないもの
- `/card` のビジュアル
- 本番ページの天候演出
- PR #19 のスマホ雪サイズ変更
- GIFのパレット最適化・ディザリング