### PR TITLE
夏至カラーの自動発火を停止

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@
 | `momiji` | 秋 + 晴れ | 紅葉と秋の地面 |
 | `tsukimi` | 秋 + 夜 | 月見の夜の光 |
 | `yukigeshiki` | 冬 + 雪 | 雪景色と雪の大気 |
-これらは単発の表示フラグではなく、URL・Zustandストア・季節ビジュアルプロファイルで同じ状態を参照します。ホーム左上のCLIから、たとえば `sudo make tsuyu` や `sudo make birthday` を実行して体験できます。
+これらは単発の表示フラグではなく、URL・Zustandストア・季節ビジュアルプロファイルで同じ状態を参照します。梅雨や初日の出は日付に応じて自動的に選ばれますが、夏至の専用カラーはホーム左上のCLIから `sudo make geshi` を実行したときだけ有効になります。
 
 ### 作品間の状態共有
 
@@ -222,7 +222,7 @@ Denshouo
 
 - React Three Fiber / WebGLで構成したインタラクティブな3Dワールド
 - 天候・季節・季節イベントを正規化する共有WorldState
-- 梅雨、夏至、初日の出、誕生日などの日付・状態連動イベント
+- 梅雨や初日の出などの日付連動イベント、CLIで呼び出せる夏至・誕生日プリセット
 - GitHub Planet、Otenkigurashi、ColdKeep、reCAPTCHA Game、Denshouoをつなぐ作品別遷移
 - Tone.jsによる状態連動のサウンドディレクション
 - DenshouoのWebGL検出とCSS fallback

--- a/src/lib/seasonResolver.test.ts
+++ b/src/lib/seasonResolver.test.ts
@@ -19,8 +19,8 @@ describe('resolveSeasonState', () => {
         expect(resolveSeasonState(japanDate('2026-12-01'))).toEqual({ season: 'winter', seasonEvent: 'none' });
     });
 
-    it('gives geshi precedence over the tsuyu atmosphere on the solstice', () => {
-        expect(resolveSeasonState(japanDate('2026-06-21'))).toEqual({ season: 'summer', seasonEvent: 'geshi' });
+    it('does not auto-select geshi on the solstice', () => {
+        expect(resolveSeasonState(japanDate('2026-06-21'))).toEqual({ season: 'summer', seasonEvent: 'tsuyu' });
     });
 
     it('keeps tsuyu inside its intended date range', () => {

--- a/src/lib/seasonResolver.ts
+++ b/src/lib/seasonResolver.ts
@@ -34,9 +34,6 @@ function resolveSeasonEvent(month: number, day: number): SeasonEventType {
     // 元日は初日の出の演出を選ぶ。weather=Morning のときだけ表示側で有効化する。
     if (month === 1 && day === 1) return 'first_light';
 
-    // 夏至は梅雨の雰囲気より優先して、専用の演出を選ぶ。
-    if (month === 6 && day === 21) return 'geshi';
-
     // 梅雨は日本の季節感に合わせた固定期間で表現する。
     if ((month === 6 && day >= 7) || (month === 7 && day <= 20)) return 'tsuyu';
 


### PR DESCRIPTION
## 概要
夏至専用カラーを日付で自動表示せず、ホーム左上のCLIから `sudo make geshi` を実行したときだけ有効にします。

## 変更理由
審査期間や通常の訪問時に、6月21日だけ専用の夏至カラーへ突然切り替わる状態を避けるためです。

## 変更内容
- 季節自動判定から `geshi` の日付判定を削除
- 6月21日は既存の梅雨期間判定を継続
- `sudo make geshi` による明示的な夏至プリセットは維持
- 自動判定テストを更新
- READMEに自動発火とCLI発火の違いを追記

## 変更していないもの
- 夏至カラーの配色・演出
- 梅雨、初日の出、その他の季節プリセット
- URL・ZustandによるWorldState共有
- GIF生成処理とPR #20の修正